### PR TITLE
Clarify some de/encoder docstrings

### DIFF
--- a/Data/Text/ICU/Convert.hs
+++ b/Data/Text/ICU/Convert.hs
@@ -101,8 +101,7 @@ open name mf = do
     _ -> return ()
   return c
 
--- | Convert the Unicode string into a codepage string using the given
--- converter.
+-- | Encode a Unicode string into a codepage string using the given converter.
 fromUnicode :: Converter -> Text -> ByteString
 fromUnicode cnv t =
   unsafePerformIO . useAsPtr t $ \tptr tlen ->
@@ -113,8 +112,7 @@ fromUnicode cnv t =
         fmap fromIntegral . handleError $
            ucnv_fromUChars cptr (castPtr sptr) capacity tptr (fromIntegral tlen)
 
--- | Convert the codepage string into a Unicode string using the given
--- converter.
+-- | Decode an encoded string into a Unicode string using the given converter.
 toUnicode :: Converter -> ByteString -> Text
 toUnicode cnv bs =
   unsafePerformIO . unsafeUseAsCStringLen bs $ \(sptr, slen) ->


### PR DESCRIPTION
I spent an embarassing amount of time fighting with toUnicode because I misunderstood its purpose. To me, a "Unicode string" seemed to mean an encoded string. I'm hoping that using the words "encode/decode" will help others avoid this pitfall.
