### PR TITLE
Accommodate GHC 7.8 by compiling C bits with -fPIC

### DIFF
--- a/text-icu.cabal
+++ b/text-icu.cabal
@@ -74,6 +74,7 @@ library
       Data.Text.ICU.Regex.Pure
       Data.Text.ICU.Text
   c-sources: cbits/text_icu.c
+  cc-options: -fPIC
   include-dirs: include
   extra-libraries: icuuc
   if os(mingw32)


### PR DESCRIPTION
As described in [Bitbucket issue #9](https://bitbucket.org/bos/text-icu/issue/9/ghc-78-and-fpic):

The linker changes in GHC 7.8 require building C code with `-fPIC`.

This is a problem with `text-icu-0.7.0.0`, reproducible on (at least) Ubuntu 14.04 LTS (64-bit):

```
$ apt-get install libicu-dev
$ cabal unpack text-icu-0.7.0.0
$ cd text-icu-0.7.0.0
$ cabal sandbox init
$ cabal install --dep
$ cabal configure
$ cabal build
$ cabal repl
Preprocessing library text-icu-0.7.0.0...
GHCi, version 7.8.3: http://www.haskell.org/ghc/  :? for help
Loading package ghc-prim ... linking ... done.
Loading package integer-gmp ... linking ... done.
Loading package base ... linking ... done.
Loading package array-0.5.0.0 ... linking ... done.
Loading package deepseq-1.3.0.2 ... linking ... done.
Loading package bytestring-0.10.4.0 ... linking ... done.
Loading package text-1.2.0.0 ... linking ... done.
Loading object (static) dist/build/cbits/text_icu.o ... /usr/bin/ld: dist/build/cbits/text_icu.o: relocation R_X86_64_PC32 against undefined symbol `ucnv_getMaxCharSize_52' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: Bad value
collect2: error: ld returned 1 exit status
```

The solution is to add `cc-options: -fPIC` to the Cabal package description.
