### PR TITLE
Add support for ICU 68

### DIFF
--- a/cbits/text_icu.c
+++ b/cbits/text_icu.c
@@ -305,7 +305,7 @@ int32_t __hs_u_strFoldCase(UChar *dest, int32_t destCapacity,
 
 int32_t __hs_u_strCompareIter(UCharIterator *iter1, UCharIterator *iter2)
 {
-    return u_strCompareIter(iter1, iter2, TRUE);
+    return u_strCompareIter(iter1, iter2, 1);
 }
 
 UBlockCode __hs_ublock_getCode(UChar32 c)

--- a/text-icu.cabal
+++ b/text-icu.cabal
@@ -1,5 +1,5 @@
 name:           text-icu
-version:        0.7.0.2
+version:        0.7.1.0
 synopsis:       Bindings to the ICU library
 homepage:       https://github.com/bos/text-icu
 bug-reports:    https://github.com/bos/text-icu/issues

--- a/text-icu.cabal
+++ b/text-icu.cabal
@@ -1,5 +1,5 @@
 name:           text-icu
-version:        0.55.1.0
+version:        0.7.0.2
 synopsis:       Bindings to the ICU library
 homepage:       https://github.com/bos/text-icu
 bug-reports:    https://github.com/bos/text-icu/issues


### PR DESCRIPTION
In [this commit](https://github.com/unicode-org/icu/commit/c3fe7e09d8449b3d3a8deb4fc7b3bb7c97ba38ad), ICU dropped custom defined `TRUE` and `FALSE` values in favour of `<stdbool.h>`. This means that `text-icu` currently does not support this new ICU release. This PR replaces `TRUE` with `1` to allow support for both version 68 and older releases.

I've changed the version to `0.7.0.2` to allow drop-in replacement for most packages. The current version was raised from `0.7.0.1` to `0.55.1.0`, but this was never released to Hackage.