### PR TITLE
Define TRUE and FALSE if undefined

### DIFF
--- a/cbits/text_icu.c
+++ b/cbits/text_icu.c
@@ -1,5 +1,13 @@
 #include "hs_text_icu.h"
 
+#ifndef FALSE
+#define FALSE (0)
+#endif
+
+#ifndef TRUE
+#define TRUE (!FALSE)
+#endif
+
 UBreakIterator* __hs_ubrk_open(UBreakIteratorType type, const char *locale,
 			       const UChar *text, int32_t textLength,
 			       UErrorCode *status)


### PR DESCRIPTION
Here, on my system it does not compile without these `#defines`. Actually TRUE and FALSE are not C keywords and must be imported from anywhere and I can't find these on my system (Manjaro Linux).

With this path, it properly compiles.