### PR TITLE
Add lib/include dirs for newer homebrew

### DIFF
--- a/text-icu.cabal
+++ b/text-icu.cabal
@@ -82,8 +82,12 @@ library
   c-sources: cbits/text_icu.c
   include-dirs: include
   if os(darwin)
-    extra-lib-dirs: /usr/local/opt/icu4c/lib
-    include-dirs: /usr/local/opt/icu4c/include
+    extra-lib-dirs:
+      /usr/local/opt/icu4c/lib
+      /opt/homebrew/opt/icu4c/lib
+    include-dirs:
+      /usr/local/opt/icu4c/include
+      /opt/homebrew/opt/icu4c/include
   extra-libraries: icuuc
   if os(mingw32)
     extra-libraries: icuin icudt


### PR DESCRIPTION
I'm not sure why these changed, but this is the location on my m1 mac
with a standard brew installation.