### PR TITLE
Support for text-2.0

### DIFF
--- a/Data/Text/ICU/Break/Pure.hs
+++ b/Data/Text/ICU/Break/Pure.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE BangPatterns, RecordWildCards #-}
+{-# LANGUAGE BangPatterns, RecordWildCards, CPP #-}
 -- |
 -- Module      : Data.Text.ICU.Break.Pure
 -- Copyright   : (c) 2010 Bryan O'Sullivan
@@ -40,10 +40,9 @@ module Data.Text.ICU.Break.Pure
 
 import Control.DeepSeq (NFData(..))
 import Data.Text (Text, empty)
-import Data.Text.Foreign (dropWord16, takeWord16)
 import Data.Text.ICU.Break (Line, Word)
 import Data.Text.ICU.Break.Types (BreakIterator(..))
-import Data.Text.ICU.Internal (LocaleName)
+import Data.Text.ICU.Internal (LocaleName, takeWord, dropWord)
 import System.IO.Unsafe (unsafeInterleaveIO, unsafePerformIO)
 import qualified Data.Text.ICU.Break as IO
 
@@ -115,8 +114,8 @@ breaks (B b) t = unsafePerformIO $ do
           Just n -> do
             s <- IO.getStatus bi
             let d = n-p
-                u = dropWord16 p t
-            (Break (takeWord16 p t) (takeWord16 d u) (dropWord16 d u) s :) `fmap` go n
+                u = dropWord p t
+            (Break (takeWord p t) (takeWord d u) (dropWord d u) s :) `fmap` go n
   unsafeInterleaveIO $ go =<< IO.first bi
 
 -- | Return a list of all breaks in a string, from right to left.
@@ -131,6 +130,6 @@ breaksRight (B b) t = unsafePerformIO $ do
           Just n -> do
             s <- IO.getStatus bi
             let d = p-n
-                u = dropWord16 n t
-            (Break (takeWord16 n t) (takeWord16 d u) (dropWord16 d u) s :) `fmap` go n
+                u = dropWord n t
+            (Break (takeWord n t) (takeWord d u) (dropWord d u) s :) `fmap` go n
   unsafeInterleaveIO $ go =<< IO.last bi

--- a/Data/Text/ICU/Break/Types.hs
+++ b/Data/Text/ICU/Break/Types.hs
@@ -16,12 +16,12 @@ module Data.Text.ICU.Break.Types
 
 import Data.IORef (IORef)
 import Data.Int (Int32)
-import Data.Text (Text)
 import Foreign.ForeignPtr (ForeignPtr)
+import Data.Text.ICU.Internal (UTextPtr)
 
 -- A boundary breaker.
 data BreakIterator a = BR {
-      brText :: IORef Text
+      brText :: IORef UTextPtr
     , brStatus :: Int32 -> a
     , brIter :: ForeignPtr UBreakIterator
     }

--- a/Data/Text/ICU/CaseMap.hsc
+++ b/Data/Text/ICU/CaseMap.hsc
@@ -22,6 +22,7 @@ module Data.Text.ICU.CaseMap
 #include <unicode/ucasemap.h>
 #include <unicode/uchar.h>
 
+import Control.Exception (mask_)
 import Data.Bits ((.|.))
 import Data.List (foldl')
 import Data.Text.ICU.Error.Internal (UErrorCode, handleError)
@@ -56,7 +57,7 @@ reduceCaseMapOptions = foldl' (.|.) (#const U_FOLD_CASE_DEFAULT) .
                        map fromCaseMapOption
 
 caseMap :: LocaleName -> [CaseOption] -> CaseMap
-caseMap name opts = unsafePerformIO $ do
+caseMap name opts = unsafePerformIO $ mask_ $ do
   p <- withLocaleName name $ \nptr -> handleError . ucasemap_open nptr .
        reduceCaseMapOptions $ opts
   CaseMap `fmap` newForeignPtr ucasemap_close p

--- a/Data/Text/ICU/Char.hsc
+++ b/Data/Text/ICU/Char.hsc
@@ -131,6 +131,10 @@ data Direction =
   | PopDirectionalFormat
   | DirNonSpacingMark
   | BoundaryNeutral
+  | FirstStrongIsolate
+  | LeftToRightIsolate
+  | RightToLeftIsolate
+  | PopDirectionalIsolate
   deriving (Eq, Enum, Show, Typeable)
 
 instance NFData Direction where
@@ -401,6 +405,83 @@ data BlockCode =
   | OldHungarian
   | SupplementalSymbolsAndPictographs
   | SuttonSignwriting
+
+    -- New blocks in Unicode 9.0 (ICU 58)
+
+  | Adlam
+  | Bhaiksuki
+  | CyrillicExtendedC
+  | GlagoliticSupplement
+  | IdeographicSymbolsAndPunctuation
+  | Marchen
+  | MongolianSupplement
+  | Newa
+  | Osage
+  | Tangut
+  | TangutComponents
+
+    -- New blocks in Unicode 10.0 (ICU 60)
+
+  | CjkUnifiedIdeographsExtensionF
+  | KanaExtendedA
+  | MasaramGondi
+  | Nushu
+  | Soyombo
+  | SyriacSupplement
+  | ZanabazarSquare
+
+    -- New blocks in Unicode 11.0 (ICU 62)
+
+  | ChessSymbols
+  | Dogra
+  | GeorgianExtended
+  | GunjalaGondi
+  | HanifiRohingya
+  | IndicSiyaqNumbers
+  | Makasar
+  | MayanNumerals
+  | Medefaidrin
+  | OldSogdian
+  | Sogdian
+
+    -- New blocks in Unicode 12.0 (ICU 64)
+
+  | EgyptianHieroglyphFormatControls
+  | Elymaic
+  | Nandinagari
+  | NyiakengPuachueHmong
+  | OttomanSiyaqNumbers
+  | SmallKanaExtension
+  | SymbolsAndPictographsExtendedA
+  | TamilSupplement
+  | Wancho
+
+    -- New blocks in Unicode 13.0 (ICU 66)
+
+  | Chorasmian
+  | CjkUnifiedIdeographsExtensionG
+  | DivesAkuru
+  | KhitanSmallScript
+  | LisuSupplement
+  | SymbolsForLegacyComputing
+  | TangutSupplement
+  | Yezidi
+
+    -- New blocks in Unicode 14.0 (ICU 70)
+
+  | ArabicExtendedB
+  | CyproMinoan
+  | EthiopicExtendedB
+  | KanaExtendedB
+  | LatinExtendedF
+  | LatinExtendedG
+  | OldUyghur
+  | Tangsa
+  | Toto
+  | UnifiedCanadianAboriginalSyllabicsExtendedA
+  | Vithkuqi
+  | ZnamennyMusicalNotation
+
   deriving (Eq, Enum, Bounded, Show, Typeable)
 
 instance NFData BlockCode where

--- a/Data/Text/ICU/Collate/Internal.hs
+++ b/Data/Text/ICU/Collate/Internal.hs
@@ -20,6 +20,7 @@ module Data.Text.ICU.Collate.Internal
     , wrap
     ) where
 
+import Control.Exception (mask_)
 import Data.Typeable (Typeable)
 import Foreign.ForeignPtr (ForeignPtr, newForeignPtr, withForeignPtr)
 import Foreign.Ptr (FunPtr, Ptr)
@@ -41,8 +42,8 @@ withCollator :: MCollator -> (Ptr UCollator -> IO a) -> IO a
 withCollator (MCollator col) action = withForeignPtr col action
 {-# INLINE withCollator #-}
 
-wrap :: Ptr UCollator -> IO MCollator
-wrap = fmap MCollator . newForeignPtr ucol_close
+wrap :: IO (Ptr UCollator) -> IO MCollator
+wrap a = mask_ $ fmap MCollator $ newForeignPtr ucol_close =<< a
 {-# INLINE wrap #-}
 
 foreign import ccall unsafe "hs_text_icu.h &__hs_ucol_close" ucol_close

--- a/Data/Text/ICU/Convert.hs
+++ b/Data/Text/ICU/Convert.hs
@@ -113,7 +113,7 @@ fromUnicode :: Converter -> Text -> ByteString
 fromUnicode cnv t =
   unsafePerformIO . useAsPtr t $ \tptr tlen ->
     withConverter cnv $ \cptr -> do
-      let capacity = fromIntegral . max_bytes_for_string cptr . fromIntegral $
+      let capacity = fromIntegral . ucnv_max_bytes_for_string cptr . fromIntegral $
                      lengthWord t
       createAndTrim (fromIntegral capacity) $ \sptr ->
         fmap fromIntegral . handleError $
@@ -199,7 +199,7 @@ foreign import ccall unsafe "hs_text_icu.h __hs_ucnv_open" ucnv_open
 foreign import ccall unsafe "hs_text_icu.h &__hs_ucnv_close" ucnv_close
     :: FunPtr (Ptr UConverter -> IO ())
 
-foreign import ccall unsafe "__get_max_bytes_for_string" max_bytes_for_string
+foreign import ccall unsafe "__hs_ucnv_get_max_bytes_for_string" ucnv_max_bytes_for_string
     :: Ptr UConverter -> CInt -> CInt
 
 #if MIN_VERSION_text(2,0,0)

--- a/Data/Text/ICU/Internal.hsc
+++ b/Data/Text/ICU/Internal.hsc
@@ -205,7 +205,7 @@ fromUCharPtr p l =
             (fromIntegral l) err
         dl <- peek dstLen
         fromPtr dst (fromIntegral dl)
-    where capacity = fromIntegral l * 2
+    where capacity = fromIntegral l * 3
 
 dropWord = dropWord8
 takeWord = takeWord8

--- a/Data/Text/ICU/Internal.hsc
+++ b/Data/Text/ICU/Internal.hsc
@@ -1,4 +1,4 @@
-{-# LANGUAGE EmptyDataDecls, ForeignFunctionInterface #-}
+{-# LANGUAGE EmptyDataDecls, ForeignFunctionInterface, GeneralizedNewtypeDeriving, TupleSections #-}
 
 module Data.Text.ICU.Internal
     (
@@ -8,28 +8,45 @@ module Data.Text.ICU.Internal
     , UChar32
     , UCharIterator
     , CharIterator(..)
+    , UText, UTextPtr
     , asBool
     , asOrdering
     , withCharIterator
     , withLocaleName
     , withName
+    , useAsUCharPtr, fromUCharPtr, I16, asUCharForeignPtr
+    , asUTextPtr, withUTextPtr, withUTextPtrText, emptyUTextPtr, utextPtrLength
+    , TextI, takeWord, dropWord, lengthWord
     ) where
 
 #include <unicode/uiter.h>
 
+import Control.Exception (mask_)
 import Control.DeepSeq (NFData(..))
 import Data.ByteString.Internal (ByteString(..))
-import Data.Int (Int8, Int32)
+import Data.Int (Int8, Int32, Int64)
 import Data.String (IsString(..))
-import Data.Text (Text)
+import Data.Text (Text, empty)
 import Data.Text.Encoding (decodeUtf8)
-import Data.Text.Foreign (useAsPtr)
+import Data.Text.Foreign (useAsPtr, asForeignPtr, fromPtr)
+#if MIN_VERSION_text(2,0,0)
+import Data.Text.Foreign (I8, dropWord8, takeWord8, lengthWord8)
+import Data.Word (Word8)
+import Foreign.ForeignPtr (mallocForeignPtrArray)
+import Foreign.Marshal.Array (allocaArray)
+import Foreign.Storable (peek)
+#else
+import Data.Text.Foreign (I16, dropWord16, takeWord16, lengthWord16)
+#endif
 import Data.Word (Word16, Word32)
 import Foreign.C.String (CString, withCString)
 import Foreign.C.Types (CChar)
+import Foreign.ForeignPtr (withForeignPtr, ForeignPtr, newForeignPtr)
 import Foreign.Marshal.Alloc (allocaBytes)
-import Foreign.ForeignPtr (withForeignPtr)
-import Foreign.Ptr (Ptr, castPtr, nullPtr)
+import Foreign.Marshal.Utils (with)
+import Foreign.Ptr (Ptr, castPtr, nullPtr, FunPtr)
+import Data.Text.ICU.Error.Internal (UErrorCode)
+import System.IO.Unsafe (unsafePerformIO)
 
 -- | A type that supports efficient iteration over Unicode characters.
 --
@@ -55,7 +72,11 @@ withCharIterator (CIUTF8 (PS fp _ l)) act =
     uiter_setUTF8 i (castPtr p) (fromIntegral l) >> act i
 withCharIterator (CIText t) act =
     allocaBytes (#{size UCharIterator}) $ \i -> useAsPtr t $ \p l ->
+#if MIN_VERSION_text(2,0,0)
+    uiter_setUTF8 i (castPtr p) (fromIntegral l) >> act i
+#else
     uiter_setString i p (fromIntegral l) >> act i
+#endif
 
 type UBool   = Int8
 type UChar   = Word16
@@ -99,8 +120,123 @@ withLocaleName Current act = act nullPtr
 withLocaleName Root act = withCString "" act
 withLocaleName (Locale n) act = withCString n act
 
+#if !MIN_VERSION_text(2,0,0)
 foreign import ccall unsafe "hs_text_icu.h __hs_uiter_setString" uiter_setString
     :: Ptr UCharIterator -> Ptr UChar -> Int32 -> IO ()
+#endif
 
 foreign import ccall unsafe "hs_text_icu.h __hs_uiter_setUTF8" uiter_setUTF8
     :: Ptr UCharIterator -> Ptr CChar -> Int32 -> IO ()
+
+
+data UText
+
+-- | Pointer to UText which also keeps pointer to source text so it won't be
+-- garbage collected.
+data UTextPtr
+    = UTextPtr
+      { utextPtr :: ForeignPtr UText
+      , utextPtrText :: ForeignPtr TextChar
+      , utextPtrLength :: TextI
+      }
+
+emptyUTextPtr :: UTextPtr
+emptyUTextPtr = unsafePerformIO $ asUTextPtr empty
+{-# NOINLINE emptyUTextPtr #-}
+
+withUTextPtr :: UTextPtr -> (Ptr UText -> IO a) -> IO a
+withUTextPtr = withForeignPtr . utextPtr
+
+withUTextPtrText :: UTextPtr -> (Ptr TextChar -> IO a) -> IO a
+withUTextPtrText = withForeignPtr . utextPtrText
+
+-- | Returns UTF-8 UText for text >= 2.0 or UTF-16 UText for previous versions.
+asUTextPtr :: Text -> IO UTextPtr
+asUTextPtr t = do
+    (fp,l) <- asForeignPtr t
+    with 0 $ \ e -> withForeignPtr fp $ \ p -> mask_ $ do
+        ut <- newForeignPtr utext_close =<<
+#if MIN_VERSION_text(2,0,0)
+            utext_openUTF8
+#else
+            utext_openUChars
+#endif
+            nullPtr p (fromIntegral l) e
+        return $ UTextPtr ut fp l
+
+foreign import ccall unsafe "hs_text_icu.h &__hs_utext_close" utext_close
+    :: FunPtr (Ptr UText -> IO ())
+
+useAsUCharPtr :: Text -> (Ptr UChar -> I16 -> IO a) -> IO a
+asUCharForeignPtr :: Text -> IO (ForeignPtr UChar, I16)
+fromUCharPtr :: Ptr UChar -> I16 -> IO Text
+
+dropWord, takeWord :: TextI -> Text -> Text
+lengthWord :: Text -> Int
+
+#if MIN_VERSION_text(2,0,0)
+newtype I16 = I16 Int
+    deriving (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
+
+type TextChar = Word8
+type TextI = I8
+
+useAsUCharPtr t act = useAsPtr t $ \tptr tlen ->
+    allocaArray (fromIntegral tlen) $ \ dst ->
+        act dst =<< fromUtf8 dst tptr tlen
+
+asUCharForeignPtr t = useAsPtr t $ \tptr tlen -> do
+    fp <- mallocForeignPtrArray (fromIntegral tlen)
+    withForeignPtr fp $ \ dst -> (fp,) <$> fromUtf8 dst tptr tlen
+
+fromUtf8 :: Ptr UChar -> Ptr Word8 -> I8 -> IO I16
+fromUtf8 dst tptr tlen =
+    with 0 $ \ err ->
+    with 0 $ \ dstLen -> do
+        _ <- u_strFromUTF8Lenient dst (fromIntegral tlen) dstLen tptr
+              (fromIntegral tlen) err
+        fromIntegral <$> peek dstLen
+
+fromUCharPtr p l =
+    with 0 $ \ err ->
+    with 0 $ \ dstLen ->
+    allocaArray capacity $ \ dst -> do
+        _ <- u_strToUTF8 dst (fromIntegral capacity) dstLen p
+            (fromIntegral l) err
+        dl <- peek dstLen
+        fromPtr dst (fromIntegral dl)
+    where capacity = fromIntegral l * 2
+
+dropWord = dropWord8
+takeWord = takeWord8
+lengthWord = lengthWord8
+
+foreign import ccall unsafe "hs_text_icu.h __hs_u_strFromUTF8Lenient" u_strFromUTF8Lenient
+    :: Ptr UChar -> Int32 -> Ptr Int32 -> Ptr Word8 -> Int32 -> Ptr UErrorCode
+    -> IO CString
+
+foreign import ccall unsafe "hs_text_icu.h __hs_u_strToUTF8" u_strToUTF8
+    :: Ptr Word8 -> Int32 -> Ptr Int32 -> Ptr UChar -> Int32 -> Ptr UErrorCode
+    -> IO CString
+
+foreign import ccall unsafe "hs_text_icu.h __hs_utext_openUTF8" utext_openUTF8
+    :: Ptr UText -> Ptr Word8 -> Int64 -> Ptr UErrorCode -> IO (Ptr UText)
+
+#else
+
+type TextChar = UChar
+type TextI = I16
+
+-- text < 2.0 has UChar as internal representation.
+useAsUCharPtr = useAsPtr
+asUCharForeignPtr = asForeignPtr
+fromUCharPtr = fromPtr
+
+dropWord = dropWord16
+takeWord = takeWord16
+lengthWord = lengthWord16
+
+foreign import ccall unsafe "hs_text_icu.h __hs_utext_openUChars" utext_openUChars
+    :: Ptr UText -> Ptr UChar -> Int64 -> Ptr UErrorCode -> IO (Ptr UText)
+
+#endif

--- a/Data/Text/ICU/Spoof/Internal.hs
+++ b/Data/Text/ICU/Spoof/Internal.hs
@@ -24,6 +24,7 @@ module Data.Text.ICU.Spoof.Internal
     , wrapWithSerialized
     ) where
 
+import Control.Exception (mask_)
 import Data.Typeable (Typeable)
 import Data.Word (Word8)
 import Foreign.ForeignPtr (ForeignPtr, newForeignPtr, withForeignPtr)
@@ -54,8 +55,8 @@ withSpoof (MSpoof _ spoof) = withForeignPtr spoof
 
 -- | Wraps a raw 'USpoof' handle in an 'MSpoof', closing the handle when
 -- the last reference to the object is dropped.
-wrap :: Ptr USpoof -> IO MSpoof
-wrap = fmap (MSpoof Nothing) . newForeignPtr uspoof_close
+wrap :: IO (Ptr USpoof) -> IO MSpoof
+wrap a = mask_ $ fmap (MSpoof Nothing) $ newForeignPtr uspoof_close =<< a
 {-# INLINE wrap #-}
 
 -- | Wraps a previously serialized spoof checker and raw 'USpoof' handle

--- a/Data/Text/ICU/Spoof/Pure.hs
+++ b/Data/Text/ICU/Spoof/Pure.hs
@@ -68,6 +68,7 @@ applySpoofParams (SpoofParams c lev loc) s = unsafePerformIO $ do
 -- 'S.SpoofCheck's except 'CharLimit').
 spoof :: Spoof
 spoof = unsafePerformIO $ S `fmap` S.open
+{-# NOINLINE spoof #-}
 
 -- | Open an immutable 'Spoof' checker with specific 'SpoofParams'
 -- to control its behavior.

--- a/cbits/text_icu.c
+++ b/cbits/text_icu.c
@@ -13,10 +13,10 @@ void __hs_ubrk_close(UBreakIterator *bi)
     ubrk_close(bi);
 }
 
-void __hs_ubrk_setText(UBreakIterator* bi, const UChar *text,
-		       int32_t textLength, UErrorCode *status)
+void __hs_ubrk_setUText(UBreakIterator* bi, UText *text,
+                        UErrorCode *status)
 {
-    ubrk_setText(bi, text, textLength, status);
+    ubrk_setUText(bi, text, status);
 }
 
 UBreakIterator * __hs_ubrk_safeClone(const UBreakIterator *bi,
@@ -117,6 +117,13 @@ UCollationResult __hs_ucol_strcoll(const UCollator *coll,
     return ucol_strcoll(coll, source, sourceLength, target, targetLength);
 }
 
+UCollationResult __hs_ucol_strcollUTF8(
+    const UCollator *coll, const char *source, int32_t sourceLength,
+    const char *target, int32_t targetLength, UErrorCode *status)
+{
+    return ucol_strcollUTF8(coll, source, sourceLength, target, targetLength, status);
+}
+
 UCollationResult __hs_ucol_strcollIter(const UCollator *coll,
 				       UCharIterator *sIter,
 				       UCharIterator *tIter,
@@ -172,11 +179,27 @@ int32_t __hs_ucnv_toUChars(UConverter *cnv, UChar *dest, int32_t destCapacity,
     return ucnv_toUChars(cnv, dest, destCapacity, src, srcLength, pErrorCode);
 }
 
+int32_t __hs_ucnv_toAlgorithmic_UTF8(
+    UConverter *cnv, char *dest, int32_t destCapacity,
+    const char *src, int32_t srcLength,
+    UErrorCode *pErrorCode)
+{
+    return ucnv_toAlgorithmic(UCNV_UTF8, cnv, dest, destCapacity, src, srcLength, pErrorCode);
+}
+
 int32_t __hs_ucnv_fromUChars(UConverter *cnv, char *dest, int32_t destCapacity,
 			     const UChar *src, int32_t srcLength,
 			     UErrorCode *pErrorCode)
 {
     return ucnv_fromUChars(cnv, dest, destCapacity, src, srcLength, pErrorCode);
+}
+
+int32_t __hs_ucnv_fromAlgorithmic_UTF8(
+    UConverter *cnv, char *dest, int32_t destCapacity,
+    const char *src, int32_t srcLength,
+    UErrorCode *pErrorCode)
+{
+    return ucnv_fromAlgorithmic(cnv, UCNV_UTF8, dest, destCapacity, src, srcLength, pErrorCode);
 }
 
 int __hs_ucnv_compareNames(const char *name1, const char *name2)
@@ -309,6 +332,22 @@ int32_t __hs_u_strCompareIter(UCharIterator *iter1, UCharIterator *iter2)
     return u_strCompareIter(iter1, iter2, true);
 }
 
+UChar* __hs_u_strFromUTF8Lenient(
+    UChar *dest, int32_t destCapacity, int32_t *pDestLength,
+    const char *src, int32_t srcLength, UErrorCode *pErrorCode)
+{
+    return u_strFromUTF8Lenient(dest, destCapacity, pDestLength,
+                                src, srcLength, pErrorCode);
+}
+
+char* __hs_u_strToUTF8(
+    char *dest, int32_t destCapacity, int32_t *pDestLength,
+    const UChar *src, int32_t srcLength,
+    UErrorCode *pErrorCode)
+{
+    return u_strToUTF8(dest, destCapacity, pDestLength, src, srcLength, pErrorCode);
+}
+
 UBlockCode __hs_ublock_getCode(UChar32 c)
 {
     return ublock_getCode(c);
@@ -404,10 +443,10 @@ int32_t __hs_uregex_flags(const URegularExpression *regexp,
     return uregex_flags(regexp, status);
 }
 
-void __hs_uregex_setText(URegularExpression *regexp, const UChar *text,
-			 int32_t textLength, UErrorCode *status)
+void __hs_uregex_setUText(URegularExpression *regexp, UText *text,
+                          UErrorCode *status)
 {
-    return uregex_setText(regexp, text, textLength, status);
+    return uregex_setUText(regexp, text, status);
 }
 
 const UChar *__hs_uregex_getText(URegularExpression *regexp,
@@ -535,6 +574,32 @@ int32_t __hs_uspoof_getSkeleton(USpoofChecker *sc,
     return uspoof_getSkeleton(sc, type, id, length, dest, destCapacity, status);
 }
 
+int32_t __hs_uspoof_checkUTF8(
+    USpoofChecker *sc, const char *id,
+    int32_t length, int32_t *position,
+    UErrorCode *status)
+{
+    return uspoof_checkUTF8(sc, id, length, position, status);
+}
+
+int32_t __hs_uspoof_areConfusableUTF8(
+    USpoofChecker *sc,
+    const char *id1, int32_t length1,
+    const char *id2, int32_t length2,
+    UErrorCode *status)
+{
+    return uspoof_areConfusableUTF8(sc, id1, length1, id2, length2, status);
+}
+
+int32_t __hs_uspoof_getSkeletonUTF8(
+    USpoofChecker *sc,
+    int32_t type, const char *id, int32_t length,
+    char *dest, int32_t destCapacity,
+    UErrorCode *status)
+{
+    return uspoof_getSkeletonUTF8(sc, type, id, length, dest, destCapacity, status);
+}
+
 int32_t __hs_uspoof_serialize(USpoofChecker *sc, void *data, int32_t capacity,
                               UErrorCode *status)
 {
@@ -544,4 +609,19 @@ int32_t __hs_uspoof_serialize(USpoofChecker *sc, void *data, int32_t capacity,
 void __hs_uspoof_close(USpoofChecker *sc)
 {
     uspoof_close(sc);
+}
+
+UText* __hs_utext_openUChars(UText *ut, const UChar *s, int64_t length,
+                             UErrorCode * status)
+{
+    return utext_openUChars(ut, s, length, status);
+}
+UText* __hs_utext_openUTF8(UText *ut, const char *s, int64_t length,
+                           UErrorCode * status)
+{
+    return utext_openUTF8(ut, s, length, status);
+}
+void __hs_utext_close(UText *ut)
+{
+    utext_close(ut);
 }

--- a/cbits/text_icu.c
+++ b/cbits/text_icu.c
@@ -147,7 +147,7 @@ int32_t __hs_ucol_getSortKey(const UCollator *coll,
     return ucol_getSortKey(coll, source, sourceLength, result, resultLength);
 }
 
-int __get_max_bytes_for_string(UConverter *cnv, int src_length)
+int __hs_ucnv_get_max_bytes_for_string(UConverter *cnv, int src_length)
 {
     return UCNV_GET_MAX_BYTES_FOR_STRING(src_length, ucnv_getMaxCharSize(cnv));
 }

--- a/include/hs_text_icu.h
+++ b/include/hs_text_icu.h
@@ -13,6 +13,7 @@
 #include "unicode/uregex.h"
 #include "unicode/uspoof.h"
 #include "unicode/ustring.h"
+#include "unicode/utext.h"
 
 #include <stdint.h>
 
@@ -22,8 +23,8 @@ UBreakIterator* __hs_ubrk_open(UBreakIteratorType type, const char *locale,
 			       const UChar *text, int32_t textLength,
 			       UErrorCode *status);
 void __hs_ubrk_close(UBreakIterator *bi);
-void __hs_ubrk_setText(UBreakIterator* bi, const UChar *text,
-		       int32_t textLength, UErrorCode *status);
+void __hs_ubrk_setUText(UBreakIterator* bi, UText *text,
+                        UErrorCode *status);
 UBreakIterator * __hs_ubrk_safeClone(const UBreakIterator *bi,
 				     void *stackBuffer, int32_t *pBufferSize,
 				     UErrorCode *status);
@@ -70,6 +71,9 @@ UColAttributeValue __hs_ucol_getAttribute(const UCollator *coll,
 UCollationResult __hs_ucol_strcoll(const UCollator *coll,
 				   const UChar *source, int32_t sourceLength,
 				   const UChar *target, int32_t targetLength);
+UCollationResult __hs_ucol_strcollUTF8(
+    const UCollator *coll, const char *source, int32_t sourceLength,
+    const char *target, int32_t targetLength, UErrorCode *status);
 UCollationResult __hs_ucol_strcollIter(const UCollator *coll,
 				       UCharIterator *sIter,
 				       UCharIterator *tIter,
@@ -95,6 +99,14 @@ int32_t __hs_ucnv_toUChars(UConverter *cnv, UChar *dest, int32_t destCapacity,
 int32_t __hs_ucnv_fromUChars(UConverter *cnv, char *dest, int32_t destCapacity,
 			     const UChar *src, int32_t srcLength,
 			     UErrorCode *pErrorCode);
+int32_t __hs_ucnv_toAlgorithmic_UTF8(
+    UConverter *cnv, char *dest, int32_t destCapacity,
+    const char *src, int32_t srcLength,
+    UErrorCode *pErrorCode);
+int32_t __hs_ucnv_fromAlgorithmic_UTF8(
+    UConverter *cnv, char *dest, int32_t destCapacity,
+    const char *src, int32_t srcLength,
+    UErrorCode *pErrorCode);
 int __hs_ucnv_compareNames(const char *name1, const char *name2);
 const char *__hs_ucnv_getDefaultName(void);
 void __hs_ucnv_setDefaultName(const char *name);
@@ -148,8 +160,8 @@ const UChar *__hs_uregex_pattern(const URegularExpression *regexp,
 				 int32_t *patLength, UErrorCode *status);
 int32_t __hs_uregex_flags(const URegularExpression *regexp,
 			  UErrorCode *status);
-void __hs_uregex_setText(URegularExpression *regexp, const UChar *text,
-			 int32_t textLength, UErrorCode *status);
+void __hs_uregex_setUText(URegularExpression *regexp, UText *text,
+			  UErrorCode *status);
 const UChar *__hs_uregex_getText(URegularExpression *regexp,
 				 int32_t *textLength, UErrorCode *status);
 UBool __hs_uregex_find(URegularExpression *regexp, int32_t startIndex,
@@ -176,6 +188,14 @@ int32_t __hs_u_strToLower(UChar *dest, int32_t destCapacity,
 			  const UChar *src, int32_t srcLength,
 			  const char *locale, UErrorCode *pErrorCode);
 int32_t __hs_u_strCompareIter(UCharIterator *iter1, UCharIterator *iter2);
+
+UChar* __hs_u_strFromUTF8Lenient(
+    UChar *dest, int32_t destCapacity, int32_t *pDestLength,
+    const char *src, int32_t srcLength, UErrorCode *pErrorCode);
+char* __hs_u_strToUTF8(
+    char *dest, int32_t destCapacity, int32_t *pDestLength,
+    const UChar *src, int32_t srcLength,
+    UErrorCode *pErrorCode);
 
 /* uspoof.h */
 
@@ -215,6 +235,28 @@ int32_t __hs_uspoof_getSkeleton(USpoofChecker *sc, int32_t checks,
                                 const UChar *id, int32_t length,
                                 UChar *dest, int32_t destCapacity,
                                 UErrorCode *status);
+int32_t __hs_uspoof_checkUTF8(
+    USpoofChecker *sc, const char *id,
+    int32_t length, int32_t *position,
+    UErrorCode *status);
+int32_t __hs_uspoof_areConfusableUTF8(
+    USpoofChecker *sc,
+    const char *id1, int32_t length1,
+    const char *id2, int32_t length2,
+    UErrorCode *status);
+int32_t __hs_uspoof_getSkeletonUTF8(
+    USpoofChecker *sc, int32_t checks,
+    const char *id, int32_t length,
+    char *dest, int32_t destCapacity,
+    UErrorCode *status);
 int32_t __hs_uspoof_serialize(USpoofChecker *sc, void *data, int32_t capacity,
                               UErrorCode *status);
 void __hs_uspoof_close(USpoofChecker *sc);
+
+/* utext.t */
+
+UText* __hs_utext_openUChars(UText *ut, const UChar *s, int64_t length,
+                             UErrorCode * status);
+UText* __hs_utext_openUTF8(UText *ut, const char *s, int64_t length,
+                           UErrorCode * status);
+void __hs_utext_close(UText *ut);

--- a/include/hs_text_icu.h
+++ b/include/hs_text_icu.h
@@ -88,7 +88,7 @@ int32_t __hs_ucol_getSortKey(const UCollator *coll,
 
 /* ucnv.h */
 
-int __get_max_bytes_for_string(UConverter *cnv, int src_length);
+int __hs_ucnv_get_max_bytes_for_string(UConverter *cnv, int src_length);
 const char *__hs_u_errorName(UErrorCode code);
 const char *__hs_ucnv_getName(const UConverter *converter, UErrorCode *err);
 UConverter* __hs_ucnv_open(const char *converterName, UErrorCode *err);

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -4,23 +4,28 @@
 -- return results, without checking whether the results are correct.
 -- Weak tests are described as such.
 
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings, LambdaCase #-}
 {-# OPTIONS_GHC -fno-warn-missing-signatures #-}
-module Properties (tests) where
+module Properties (propertyTests, testCases) where
 
 import Control.DeepSeq (NFData(..))
 import Data.Function (on)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
-import Data.Text.ICU (NormalizationMode(..))
+import Data.Text.ICU (NormalizationMode(..), LocaleName(..))
 import QuickCheckUtils (NonEmptyText(..), LatinSpoofableText(..),
                         NonSpoofableText(..))
 import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
+import Test.Framework.Providers.HUnit (hUnitTestToTests)
+import Test.HUnit ((~?=))
+import qualified Test.HUnit (Test(..))
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Data.Text.ICU as I
+import qualified Data.Text.ICU.Convert as I
 import qualified Data.Text.ICU.Char as I
+import System.IO.Unsafe (unsafePerformIO)
 
 t_rnf :: (NFData b) => (a -> b) -> a -> Bool
 t_rnf f t = rnf (f t) == ()
@@ -60,9 +65,22 @@ t_quickCheck_isNormalized mode normMode txt
 
 -- Collation
 
--- This test is weak.
+t_collate a b = c a b == flipOrdering (c b a)
+    where c = I.collate I.uca
 
-t_collate_root txt = t_rnf $ I.collate I.uca txt
+flipOrdering :: Ordering -> Ordering
+flipOrdering = \ case
+    GT -> LT
+    LT -> GT
+    EQ -> EQ
+
+-- Convert
+
+converter e = unsafePerformIO $ I.open e Nothing
+
+t_convert a = I.toUnicode c (I.fromUnicode c a) == a
+    where c = converter "UTF-32"
+
 
 -- Unicode character database
 
@@ -83,12 +101,13 @@ t_numericValue = t_rnf $ I.numericValue
 
 t_nonspoofable (NonSpoofableText t) = I.spoofCheck I.spoof t == I.CheckOK
 t_spoofable (LatinSpoofableText t) = I.spoofCheck I.spoof t ==
-                                     I.CheckFailed [I.WholeScriptConfusable]
-t_confusable (NonEmptyText t) = I.areConfusable I.spoof t t ==
-                                I.CheckFailed [I.SingleScriptConfusable]
+                                     I.CheckFailed [I.RestrictionLevel]
+t_confusable (NonEmptyText t) = I.areConfusable I.spoof t t `elem`
+  [I.CheckFailed [I.MixedScriptConfusable]
+  ,I.CheckFailed [I.SingleScriptConfusable]]
 
-tests :: Test
-tests =
+propertyTests :: Test
+propertyTests =
   testGroup "Properties" [
     testProperty "t_toCaseFold" t_toCaseFold
   , testProperty "t_toLower" t_toLower
@@ -98,12 +117,13 @@ tests =
   , testProperty "t_charIterator_Utf8" t_charIterator_Utf8
   , testProperty "t_normalize" t_normalize
   , testProperty "t_quickCheck_isNormalized" t_quickCheck_isNormalized
-  , testProperty "t_collate_root" t_collate_root
+  , testProperty "t_collate" t_collate
+  , testProperty "t_convert" t_convert
   , testProperty "t_blockCode" t_blockCode
   , testProperty "t_charFullName" t_charFullName
   , testProperty "t_charName" t_charName
   , testProperty "t_combiningClass" t_combiningClass
-  , testProperty "t_direction" t_direction
+  , testProperty "t_direction" $ t_direction
 --, testProperty "t_property" t_property
   , testProperty "t_isMirrored" t_isMirrored
   , testProperty "t_mirror" t_mirror
@@ -112,4 +132,22 @@ tests =
   , testProperty "t_spoofable" t_spoofable
   , testProperty "t_nonspoofable" t_nonspoofable
   , testProperty "t_confusable" t_confusable
+  ]
+
+testCases :: Test
+testCases =
+  testGroup "Test cases" $ hUnitTestToTests $
+  Test.HUnit.TestList
+  [I.normalize NFC "Ame\x0301lie" ~?= "Amélie"
+  ,map I.brkBreak (I.breaks (I.breakWord (Locale "en_US")) "Hi, Amélie!")
+     ~?= ["Hi",","," ","Amélie","!"]
+  ,map I.brkBreak (I.breaksRight (I.breakLine (Locale "ru")) "Привет, мир!")
+     ~?= ["мир!","Привет, "]
+  ,I.fromUnicode (converter "cp1251") "Привет, мир!"
+     ~?= "\207\240\232\226\229\242, \236\232\240!"
+  ,(I.unfold I.group <$> I.findAll "[abc]+" "xx b yy ac") ~?= [["b"],["ac"]]
+  ,I.toUpper (Locale "de-DE") "ß" ~?= "SS"
+  ,I.toCaseFold False "ﬂag" ~?= "flag"
+  ,I.blockCode '\x1FA50' ~?= I.ChessSymbols
+  ,I.direction '\x2068' ~?= I.FirstStrongIsolate
   ]

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -136,18 +136,23 @@ propertyTests =
 
 testCases :: Test
 testCases =
-  testGroup "Test cases" $ hUnitTestToTests $
-  Test.HUnit.TestList
+  testGroup "Test cases" $ hUnitTestToTests $ Test.HUnit.TestList $
   [I.normalize NFC "Ame\x0301lie" ~?= "Amélie"
+  ,I.normalize NFC "(⊃｡•́︵•̀｡)⊃" ~?= "(⊃｡•́︵•̀｡)⊃"
   ,map I.brkBreak (I.breaks (I.breakWord (Locale "en_US")) "Hi, Amélie!")
      ~?= ["Hi",","," ","Amélie","!"]
   ,map I.brkBreak (I.breaksRight (I.breakLine (Locale "ru")) "Привет, мир!")
      ~?= ["мир!","Привет, "]
-  ,I.fromUnicode (converter "cp1251") "Привет, мир!"
-     ~?= "\207\240\232\226\229\242, \236\232\240!"
   ,(I.unfold I.group <$> I.findAll "[abc]+" "xx b yy ac") ~?= [["b"],["ac"]]
   ,I.toUpper (Locale "de-DE") "ß" ~?= "SS"
   ,I.toCaseFold False "ﬂag" ~?= "flag"
   ,I.blockCode '\x1FA50' ~?= I.ChessSymbols
   ,I.direction '\x2068' ~?= I.FirstStrongIsolate
   ]
+  <>
+  concat
+  [conv "ISO-2022-CN" "程序設計"  "\ESC$)A\SO3LPr\ESC$)G]CSS\SI"
+  ,conv "cp1251" "Привет, мир!"  "\207\240\232\226\229\242, \236\232\240!"
+  ]
+  where conv n f t = [I.fromUnicode c f ~?= t, I.toUnicode c t ~?= f]
+            where c = converter n

--- a/tests/QuickCheckUtils.hs
+++ b/tests/QuickCheckUtils.hs
@@ -4,16 +4,11 @@
 module QuickCheckUtils (NonEmptyText(..), LatinSpoofableText(..),
                         NonSpoofableText(..)) where
 
-import Control.Applicative ((<$>))
-import Control.DeepSeq (NFData(..))
 import Data.Text.ICU (Collator, LocaleName(..), NormalizationMode(..))
 import Data.Text.ICU.Break (available)
 import Test.QuickCheck (Arbitrary(..), Gen, elements, listOf1)
 import qualified Data.Text as T
 import qualified Data.Text.ICU as I
-
-instance NFData Ordering where
-    rnf !_  = ()
 
 instance Arbitrary T.Text where
     arbitrary = T.pack `fmap` arbitrary
@@ -35,7 +30,7 @@ instance Arbitrary NonEmptyText where
 newtype LatinSpoofableText = LatinSpoofableText { latinSpoofableText :: T.Text }
                            deriving Show
 instance Arbitrary LatinSpoofableText where
-    arbitrary = LatinSpoofableText <$> T.pack <$>
+    arbitrary = LatinSpoofableText <$> T.pack . (<>) "latin" <$>
                 listOf1 genCyrillicLatinSpoofableChar
 
 genCyrillicLatinSpoofableChar :: Gen Char

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -5,4 +5,4 @@ import Test.Framework (defaultMain)
 import qualified Properties
 
 main :: IO ()
-main = defaultMain [Properties.tests]
+main = defaultMain [Properties.propertyTests, Properties.testCases]

--- a/text-icu.cabal
+++ b/text-icu.cabal
@@ -50,7 +50,7 @@ library
     base >= 4 && < 5,
     bytestring,
     deepseq,
-    text >= 0.9.1.0
+    text >=0.9.1.0 && <1.3 || >=2.0 && <2.1
 
   exposed-modules:
       Data.Text.ICU


### PR DESCRIPTION
Hi, this PR adds support for `text-2.0` (with UTF-8 internal representation) while keeping compatibility with previous `text` versions (that use UTF-16 internally).

A few more tests were added, and some old tests were improved. You could read about more details in the first commit message d9b00c6b574682f08e8be7a8d7db764bd048b881.
