### PR TITLE
fix typo

### DIFF
--- a/Data/Text/ICU/Break.hsc
+++ b/Data/Text/ICU/Break.hsc
@@ -228,7 +228,7 @@ getStatuses BR{..} =
       _ <- handleError $ ubrk_getRuleStatusVec brk ptr n
       map brStatus `fmap` peekArray (fromIntegral n) ptr
 
--- | Determine whether the specfied position is a boundary position.
+-- | Determine whether the specified position is a boundary position.
 -- As a side effect, leaves the iterator pointing to the first
 -- boundary position at or after the given offset.
 isBoundary :: BreakIterator a -> Int -> IO Bool


### PR DESCRIPTION
Data/Text/ICU/Break.hsc

for another PR

Data/Text/ICU/Number.hsc

this comment could be improved

```
-- This module helps you to format and parse numbers for any locale. Your code
-- can be completely independent of the locale conventions for decimal points,
-- thousands-separators, or even the particular decimal digits used, or whether
-- the number format is even decimal. There are different number format styles
-- like decimal, currency, percent and spellout.
```