### PR TITLE
fix typos

### DIFF
--- a/Data/Text/ICU.hs
+++ b/Data/Text/ICU.hs
@@ -216,7 +216,7 @@ import Data.Text (Text)
 --
 -- You create a 'NumberFormat' with 'numberFormatter' according to a locale
 -- and a choice of pre-defined formats. A 'NumberFormat' provides a formatting
--- faclity that 'format's numbers
+-- facility that 'format's numbers
 -- according to the chosen locale. Alternatively create and apply a 'NumberFormat'
 -- in a single step with 'formatNumber'' (it may be faster to re-use a NumberFormat though).
 -- See the section \"Patterns\" at <https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/classDecimalFormat.html#Patterns>

--- a/Data/Text/ICU/BiDi.hsc
+++ b/Data/Text/ICU/BiDi.hsc
@@ -8,8 +8,8 @@
 -- Stability   : experimental
 -- Portability : GHC
 --
--- Implementation of Unicode Bidirection algorithm. See documentation of the libicu
--- library for additional details.
+-- Implementation of the Unicode Bidirectional Algorithm. See the documentation
+-- of the libicu library for additional details.
 --
 -- -- /Note/: this module is not thread safe. /Do not/ call the
 -- functions on one BiDi object from more than one thread!

--- a/Data/Text/ICU/Break.hsc
+++ b/Data/Text/ICU/Break.hsc
@@ -70,7 +70,7 @@ import System.IO.Unsafe (unsafePerformIO)
 --
 -- /Important note/: All of the indices accepted and returned by
 -- functions in this module are offsets into the raw UTF-16 text
--- array, /not/ a count of code points.
+-- array, /not/ a count of codepoints.
 
 -- | Line break status.
 data Line = Soft                -- ^ A soft line break is a position at

--- a/Data/Text/ICU/Calendar.hsc
+++ b/Data/Text/ICU/Calendar.hsc
@@ -58,7 +58,7 @@ import System.IO.Unsafe (unsafePerformIO)
 
 type UCalendar = CInt
 
--- A 'Calendar' is an absttract data type that contains a foreign pointer to the ICU internal data structure.
+-- A 'Calendar' is an abstract data type that contains a foreign pointer to the ICU internal data structure.
 data Calendar = Calendar {calendarForeignPtr :: ForeignPtr UCalendar}
 
 -- | All the fields that comprise a 'Calendar'.

--- a/Data/Text/ICU/Char.hsc
+++ b/Data/Text/ICU/Char.hsc
@@ -13,7 +13,7 @@
 -- Access to the Unicode Character Database, implemented as bindings
 -- to the International Components for Unicode (ICU) libraries.
 --
--- Unicode assigns each code point (not just assigned character) values for
+-- Unicode assigns each codepoint (not just assigned character) values for
 -- many properties.  Most are simple boolean flags, or constants from a
 -- small enumerated list.  For some, values are relatively more complex
 -- types.
@@ -1147,14 +1147,14 @@ blockCode :: Char -> BlockCode
 blockCode = toEnum . fromIntegral . ublock_getCode . fromIntegral . ord
 {-# INLINE blockCode #-}
 
--- | Return the bidirectional category value for the code point,
+-- | Return the bidirectional category value for the codepoint,
 -- which is used in the Unicode bidirectional algorithm (UAX #9
 -- <http://www.unicode.org/reports/tr9/>).
 direction :: Char -> Direction
 direction = toEnum . fromIntegral . u_charDirection . fromIntegral . ord
 {-# INLINE direction #-}
 
--- | Determine whether the code point has the 'BidiMirrored' property.  This
+-- | Determine whether the codepoint has the 'BidiMirrored' property.  This
 -- property is set for characters that are commonly used in Right-To-Left
 -- contexts and need to be displayed with a "mirrored" glyph.
 isMirrored :: Char -> Bool
@@ -1164,13 +1164,13 @@ isMirrored = asBool . u_isMirrored . fromIntegral . ord
 -- Map the specified character to a "mirror-image" character.
 --
 -- For characters with the 'BidiMirrored' property, implementations
--- sometimes need a "poor man's" mapping to another Unicode (code point)
+-- sometimes need a "poor man's" mapping to another Unicode (codepoint)
 -- such that the default glyph may serve as the mirror image of the default
 -- glyph of the specified character. This is useful for text conversion to
 -- and from code pages with visual order, and for displays without glyph
 -- selection capabilities.
 --
--- The return value is another Unicode code point that may serve as a
+-- The return value is another Unicode codepoint that may serve as a
 -- mirror-image substitute, or the original character itself if there
 -- is no such mapping or the character lacks the 'BidiMirrored'
 -- property.
@@ -1198,7 +1198,7 @@ digitToInt c
     | otherwise = Just $! fromIntegral i
   where i = u_charDigitValue . fromIntegral . ord $ c
 
--- | Return the numeric value for a Unicode code point as defined in the
+-- | Return the numeric value for a Unicode codepoint as defined in the
 -- Unicode Character Database.
 --
 -- A 'Double' return type is necessary because some numeric values are
@@ -1220,7 +1220,7 @@ charName = charName' (#const U_UNICODE_CHAR_NAME)
 
 -- | Return the full name of a Unicode character.
 --
--- Compared to 'charName', this function gives each Unicode code point
+-- Compared to 'charName', this function gives each Unicode codepoint
 -- a unique extended name. Extended names are lowercase followed by an
 -- uppercase hexadecimal number, within angle brackets.
 charFullName :: Char -> String
@@ -1237,7 +1237,7 @@ charFromName :: String -> Maybe Char
 charFromName = charFromName' (#const U_UNICODE_CHAR_NAME)
 
 -- | Find a Unicode character by its full or extended name, and return
--- its code point value.
+-- its codepoint value.
 --
 -- The name is matched exactly and completely.
 --

--- a/Data/Text/ICU/Char.hsc
+++ b/Data/Text/ICU/Char.hsc
@@ -1167,7 +1167,7 @@ isMirrored = asBool . u_isMirrored . fromIntegral . ord
 -- sometimes need a "poor man's" mapping to another Unicode (code point)
 -- such that the default glyph may serve as the mirror image of the default
 -- glyph of the specified character. This is useful for text conversion to
--- and from codepages with visual order, and for displays without glyph
+-- and from code pages with visual order, and for displays without glyph
 -- selection capabilities.
 --
 -- The return value is another Unicode code point that may serve as a

--- a/Data/Text/ICU/Collate.hsc
+++ b/Data/Text/ICU/Collate.hsc
@@ -90,7 +90,7 @@ instance NFData CaseFirst where
 -- collation, when it is used to distinguish between Katakana and Hiragana
 -- (this is achieved by setting 'HiraganaQuaternaryMode' mode to
 -- 'True'). Otherwise, quaternary level is affected only by the number of
--- non ignorable code points in the string. Identical strength is rarely
+-- non ignorable codepoints in the string. Identical strength is rarely
 -- useful, as it amounts to codepoints of the 'NFD' form of the string.
 data Strength = Primary
               | Secondary

--- a/Data/Text/ICU/Convert.hs
+++ b/Data/Text/ICU/Convert.hs
@@ -138,7 +138,7 @@ toUnicode cnv bs =
 
 -- | Determines whether the converter uses fallback mappings or not.
 -- This flag has restrictions.  Regardless of this flag, the converter
--- will always use fallbacks from Unicode Private Use code points, as
+-- will always use fallbacks from Unicode Private Use codepoints, as
 -- well as reverse fallbacks (to Unicode).  For details see \".ucm
 -- File Format\" in the Conversion Data chapter of the ICU User Guide:
 -- <http://www.icu-project.org/userguide/conversion-data.html#ucmformat>

--- a/Data/Text/ICU/Convert.hs
+++ b/Data/Text/ICU/Convert.hs
@@ -104,7 +104,7 @@ open name mf = do
     _ -> return ()
   return c
 
--- | Encode a Unicode string into a codepage string using the given converter.
+-- | Encode a Unicode string into a code page string using the given converter.
 fromUnicode :: Converter -> Text -> ByteString
 fromUnicode cnv t =
   unsafePerformIO . useAsPtr t $ \tptr tlen ->

--- a/Data/Text/ICU/Normalize.hsc
+++ b/Data/Text/ICU/Normalize.hsc
@@ -243,7 +243,7 @@ isNormalized mode t =
                                 (toNM mode)
 
 -- | Compare two strings for canonical equivalence.  Further options
--- include case-insensitive comparison and code point order (as
+-- include case-insensitive comparison and codepoint order (as
 -- opposed to code unit order).
 --
 -- Canonical equivalence between two strings is defined as their

--- a/Data/Text/ICU/Normalize2.hsc
+++ b/Data/Text/ICU/Normalize2.hsc
@@ -370,7 +370,7 @@ reduceCompareOptions = foldl' orO (#const U_COMPARE_CODE_POINT_ORDER)
     where a `orO` b = a .|. fromCompareOption b
 
 -- | Compare two strings for canonical equivalence. Further options
--- include case-insensitive comparison and code point order (as
+-- include case-insensitive comparison and codepoint order (as
 -- opposed to code unit order).
 --
 -- Canonical equivalence between two strings is defined as their

--- a/Data/Text/ICU/Normalize2.hsc
+++ b/Data/Text/ICU/Normalize2.hsc
@@ -223,7 +223,7 @@ normalize NFKCCasefold = nfkcCasefold
 -- | Create an NFC normalizer and apply this to the given text.
 --
 -- Let's have a look at a concrete example that contains the letter a with an acute accent twice.
--- First as a comination of two codepoints and second as a canonical composite or precomposed
+-- First as a combination of two codepoints and second as a canonical composite or precomposed
 -- character. Both look exactly the same but one character consists of two and one of only one
 -- codepoint. A bytewise comparison does not give equality of these.
 --

--- a/Data/Text/ICU/Regex/Internal.hsc
+++ b/Data/Text/ICU/Regex/Internal.hsc
@@ -107,7 +107,7 @@ data MatchOption
     --
     -- By default, the matching time is not limited.
     | StackLimit Int
-    -- ^ Set the amount of heap storage avaliable for use by the match
+    -- ^ Set the amount of heap storage available for use by the match
     -- backtracking stack.
     --
     -- ICU uses a backtracking regular expression engine, with the

--- a/Data/Text/ICU/Shape.hsc
+++ b/Data/Text/ICU/Shape.hsc
@@ -56,7 +56,7 @@ data ShapeOption =
   | LettersUnshape
   -- ^ Letter shaping option: replace "shaped" letter characters by abstract ones.
   | LettersShapeTashkeelIsolated
-  -- ^ The only difference with LettersShape is that Tashkeel letters are always "shaped" into the isolated form instead of the medial form (selecting code points from the Arabic Presentation Forms-B block).
+  -- ^ The only difference with LettersShape is that Tashkeel letters are always "shaped" into the isolated form instead of the medial form (selecting codepoints from the Arabic Presentation Forms-B block).
   | PreservePresentation
   -- ^ Presentation form option: Don't replace Arabic Presentation Forms-A and Arabic Presentation Forms-B characters with 0+06xx characters, before shaping.
   | TextDirectionVisualLTR
@@ -85,7 +85,7 @@ fromShapeOption TextDirectionVisualLTR = #const U_SHAPE_TEXT_DIRECTION_VISUAL_LT
 
 -- | Shape Arabic text on a character basis.
 --
--- Text-based shaping means that some character code points in the text are replaced by
+-- Text-based shaping means that some character codepoints in the text are replaced by
 -- others depending on the context. It transforms one kind of text into another.
 -- In comparison, modern displays for Arabic text select appropriate, context-dependent font
 -- glyphs for each text element, which means that they transform text into a glyph vector.


### PR DESCRIPTION
Data/Text/ICU.hs
Data/Text/ICU/BiDi.hsc
Data/Text/ICU/Calendar.hsc
Data/Text/ICU/Char.hsc
Data/Text/ICU/Convert.hs
Data/Text/ICU/Normalize2.hsc
Data/Text/ICU/Regex/Internal.hsc

@vshabanov missed these in last 2 PRs

<hr>

Data/Text/ICU/Break.hsc
Data/Text/ICU/Char.hsc
Data/Text/ICU/Collate.hsc
Data/Text/ICU/Convert.hs
Data/Text/ICU/Normalize.hsc
Data/Text/ICU/Normalize2.hsc
Data/Text/ICU/Shape.hsc

```
$ grep -r codepoint text-icu
text-icu/Data/Text/ICU/Normalize2.hsc:-- First as a combination of two codepoints and second as a canonical composite or precomposed
text-icu/Data/Text/ICU/Normalize2.hsc:-- codepoint. A bytewise comparison does not give equality of these.
text-icu/Data/Text/ICU/Break.hsc:-- Grapheme Clusters\", which are groupings of codepoints that should be
text-icu/Data/Text/ICU/Collate.hsc:                       -- ^ Treat all codepoints with non-ignorable primary
text-icu/Data/Text/ICU/Collate.hsc:                         -- ^ Cause codepoints with primary weights that are
text-icu/Data/Text/ICU/Collate.hsc:-- useful, as it amounts to codepoints of the 'NFD' form of the string.
text-icu/Data/Text/ICU/Break/Pure.hs:-- Grapheme Clusters", which are groupings of codepoints that should be
$ grep -r "code point" text-icu
text-icu/Data/Text/ICU/Normalize.hsc:-- include case-insensitive comparison and code point order (as
text-icu/Data/Text/ICU/Normalize2.hsc:-- include case-insensitive comparison and code point order (as
text-icu/Data/Text/ICU/Break.hsc:-- array, /not/ a count of code points.
text-icu/Data/Text/ICU/Char.hsc:-- Unicode assigns each code point (not just assigned character) values for
text-icu/Data/Text/ICU/Char.hsc:-- | Return the bidirectional category value for the code point,
text-icu/Data/Text/ICU/Char.hsc:-- | Determine whether the code point has the 'BidiMirrored' property.  This
text-icu/Data/Text/ICU/Char.hsc:-- sometimes need a "poor man's" mapping to another Unicode (code point)
text-icu/Data/Text/ICU/Char.hsc:-- The return value is another Unicode code point that may serve as a
text-icu/Data/Text/ICU/Char.hsc:-- | Return the numeric value for a Unicode code point as defined in the
text-icu/Data/Text/ICU/Char.hsc:-- Compared to 'charName', this function gives each Unicode code point
text-icu/Data/Text/ICU/Char.hsc:-- its code point value.
text-icu/Data/Text/ICU/Collate.hsc:-- non ignorable code points in the string. Identical strength is rarely
text-icu/Data/Text/ICU/Shape.hsc:  -- ^ The only difference with LettersShape is that Tashkeel letters are always "shaped" into the isolated form instead of the medial form (selecting code points from the Arabic Presentation Forms-B block).
text-icu/Data/Text/ICU/Shape.hsc:-- Text-based shaping means that some character code points in the text are replaced by
text-icu/Data/Text/ICU/Convert.hs:-- will always use fallbacks from Unicode Private Use code points, as
$ 
```