### PR TITLE
Support for creating a collator from custom rules

### DIFF
--- a/Data/Text/ICU.hs
+++ b/Data/Text/ICU.hs
@@ -62,7 +62,8 @@ module Data.Text.ICU
     , Collator
     , collator
     , collatorWith
-    , collatorFrom
+    , collatorFromRules
+    , collatorFromRulesWith
     , collate
     , collateIter
     , sortKey

--- a/Data/Text/ICU.hs
+++ b/Data/Text/ICU.hs
@@ -62,6 +62,7 @@ module Data.Text.ICU
     , Collator
     , collator
     , collatorWith
+    , collatorFrom
     , collate
     , collateIter
     , sortKey

--- a/Data/Text/ICU/Collate.hsc
+++ b/Data/Text/ICU/Collate.hsc
@@ -204,11 +204,7 @@ toS Quaternary = #const UCOL_QUATERNARY
 toS Identical  = #const UCOL_IDENTICAL
 
 toDefaultS :: Maybe Strength -> UColAttributeValue
-toDefaultS (Just Primary)    = #const UCOL_PRIMARY
-toDefaultS (Just Secondary)  = #const UCOL_SECONDARY
-toDefaultS (Just Tertiary)   = #const UCOL_TERTIARY
-toDefaultS bad@(Just Quaternary) = valueError "toDefaultS" bad
-toDefaultS (Just Identical)  = #const UCOL_IDENTICAL
+toDefaultS (Just s)    = toS s
 toDefaultS Nothing  = #const UCOL_DEFAULT_STRENGTH
 
 fromOO :: UColAttributeValue -> Bool

--- a/Data/Text/ICU/Collate.hsc
+++ b/Data/Text/ICU/Collate.hsc
@@ -265,9 +265,9 @@ openRules :: Text
           -> Maybe Strength
           -- ^ The default collation strength; one of 'Just Primary', 'Just Secondary', 'Just Tertiary', 'Just Identical', 'Nothing' (default strength) - can be also set in the rules.
           -> IO MCollator
-openRules r n s = wrap $ useAsUCharPtr r $ \rptr rlen -> do
-  let len = fromIntegral rlen
-  handleParseError (== u_INVALID_FORMAT_ERROR) $ ucol_openRules rptr len (toDefaultOO n) (toDefaultS s)
+openRules r n s = wrap $ useAsUCharPtr r $ \rPtr rLen -> do
+  let len = fromIntegral rLen
+  handleParseError (== u_INVALID_FORMAT_ERROR) $ ucol_openRules rPtr len (toDefaultOO n) (toDefaultS s)
 
 -- | Set the value of an 'MCollator' attribute.
 setAttribute :: MCollator -> Attribute -> IO ()

--- a/Data/Text/ICU/Collate/Pure.hs
+++ b/Data/Text/ICU/Collate/Pure.hs
@@ -26,6 +26,7 @@ module Data.Text.ICU.Collate.Pure
     , collatorFromRulesWith
     , collate
     , collateIter
+    , rules
     , sortKey
     , uca
     ) where
@@ -71,6 +72,10 @@ collatorFromRulesWith rul atts = unsafePerformIO $
       mc <- IO.openRules rul Nothing Nothing
       forM_ atts $ IO.setAttribute mc
       return (C mc)
+
+-- | Get rules for the given 'Collator'.
+rules :: Collator -> Text
+rules (C c) = unsafePerformIO $ IO.getRules c
 
 -- | Compare two strings.
 collate :: Collator -> Text -> Text -> Ordering

--- a/Data/Text/ICU/Collate/Pure.hs
+++ b/Data/Text/ICU/Collate/Pure.hs
@@ -22,7 +22,8 @@ module Data.Text.ICU.Collate.Pure
       Collator
     , collator
     , collatorWith
-    , collatorFrom
+    , collatorFromRules
+    , collatorFromRulesWith
     , collate
     , collateIter
     , sortKey
@@ -57,17 +58,19 @@ collatorWith loc atts = unsafePerformIO $ do
   return (C mc)
 
 -- | Create an immutable 'Collator' from the given collation rules.
-collatorFrom :: Text
-                -- ^ A string describing the collation rules.
-             -> Maybe Bool
-             -- ^ The normalization mode: One of 'Just False' ()expect the text to not need normalization)
-             -- 'Just True' (normalize), or 'Nothing' (set the mode according to the rules)
-             -> Maybe IO.Strength
-             -- ^ The default collation strength; one of 'Just Primary', 'Just Secondary', 'Just Tertiary', 'Just Identical', 'Nothing' (default strength) - can be also set in the rules.
-             -> Either ParseError Collator
-collatorFrom rules norm strength = unsafePerformIO $
-  ((Right . C) `fmap` IO.openRules rules norm strength) `E.catch`
-  \(err::ParseError) -> return (Left err)
+collatorFromRules :: Text -> Either ParseError Collator
+collatorFromRules rul = collatorFromRulesWith rul []
+
+-- | Create an immutable 'Collator' from the given collation rules with the given 'Attribute's.
+collatorFromRulesWith :: Text -> [IO.Attribute] -> Either ParseError Collator
+collatorFromRulesWith rul atts = unsafePerformIO $
+  (Right `fmap` openAndSetAtts)
+  `E.catch` \(err::ParseError) -> return (Left err)
+  where
+    openAndSetAtts = do
+      mc <- IO.openRules rul Nothing Nothing
+      forM_ atts $ IO.setAttribute mc
+      return (C mc)
 
 -- | Compare two strings.
 collate :: Collator -> Text -> Text -> Ordering

--- a/cbits/text_icu.c
+++ b/cbits/text_icu.c
@@ -238,6 +238,13 @@ UCollator *__hs_ucol_open(const char *loc, UErrorCode *status)
     return ucol_open(loc, status);
 }
 
+UCollator* __hs_ucol_openRules(const UChar *rules, int32_t rulesLength,
+                               UColAttributeValue normalizationMode, UCollationStrength strength,
+                               UParseError *parseError, UErrorCode *status)
+{
+  return ucol_openRules(rules, rulesLength, normalizationMode, strength, parseError, status);
+}
+
 void __hs_ucol_close(UCollator *coll)
 {
     ucol_close(coll);

--- a/cbits/text_icu.c
+++ b/cbits/text_icu.c
@@ -250,6 +250,11 @@ void __hs_ucol_close(UCollator *coll)
     ucol_close(coll);
 }
 
+const UChar *__hs_ucol_getRules(const UCollator *coll, int32_t *length)
+{
+  return ucol_getRules(coll, length);
+}
+
 void __hs_ucol_setAttribute(UCollator *coll, UColAttribute attr,
                             UColAttributeValue value, UErrorCode *status)
 {

--- a/include/hs_text_icu.h
+++ b/include/hs_text_icu.h
@@ -114,6 +114,9 @@ double __hs_u_getNumericValue(UChar32 c);
 /* ucol.h */
 
 UCollator *__hs_ucol_open(const char *loc, UErrorCode *status);
+UCollator* __hs_ucol_openRules(const UChar *rules, int32_t rulesLength,
+                               UColAttributeValue normalizationMode, UCollationStrength strength,
+                               UParseError *parseError, UErrorCode *status);
 void __hs_ucol_close(UCollator *coll);
 void __hs_ucol_setAttribute(UCollator *coll, UColAttribute attr,
                             UColAttributeValue value, UErrorCode *status);

--- a/include/hs_text_icu.h
+++ b/include/hs_text_icu.h
@@ -118,6 +118,7 @@ UCollator* __hs_ucol_openRules(const UChar *rules, int32_t rulesLength,
                                UColAttributeValue normalizationMode, UCollationStrength strength,
                                UParseError *parseError, UErrorCode *status);
 void __hs_ucol_close(UCollator *coll);
+const UChar *__hs_ucol_getRules(const UCollator *coll, int32_t *length);
 void __hs_ucol_setAttribute(UCollator *coll, UColAttribute attr,
                             UColAttributeValue value, UErrorCode *status);
 UColAttributeValue __hs_ucol_getAttribute(const UCollator *coll,

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -13,7 +13,7 @@ import Control.DeepSeq (NFData(..))
 import Data.Function (on)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
-import Data.Text.ICU (LocaleName(..))
+import Data.Text.ICU (LocaleName(..), ParseError(..))
 import QuickCheckUtils (NonEmptyText(..), LatinSpoofableText(..),
                         NonSpoofableText(..), Utf8Text(..))
 import Data.Text.ICU.Normalize2 (NormalizationMode(..))
@@ -21,8 +21,8 @@ import qualified Data.Text.ICU.Normalize2 as I
 import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
 import Test.Framework.Providers.HUnit (hUnitTestToTests)
-import Test.HUnit ((~?=), (@?=))
-import qualified Test.HUnit (Test(..))
+import Test.HUnit ((~?=), (@?=), (~:))
+import qualified Test.HUnit (Test(..), assertFailure)
 import Test.QuickCheck.Monadic (monadicIO, run, assert)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
@@ -32,6 +32,7 @@ import qualified Data.Text.ICU.Calendar as Cal
 import qualified Data.Text.ICU.Convert as I
 import qualified Data.Text.ICU.Char as I
 import qualified Data.Text.ICU.CharsetDetection as CD
+import qualified Data.Text.ICU.Error as Err
 import qualified Data.Text.ICU.Number as N
 import qualified Data.Text.ICU.Shape as S
 import System.IO.Unsafe (unsafePerformIO)
@@ -79,6 +80,11 @@ t_quickCheck_isNormalized mode normMode txt
 
 t_collate a b = c a b == flipOrdering (c b a)
     where c = I.collate I.uca
+
+t_collate_emptyRule a b = I.collate cUca a b == I.collate cEmpty a b
+  where
+    cUca = I.uca
+    Right cEmpty = I.collatorFrom "" Nothing Nothing
 
 flipOrdering :: Ordering -> Ordering
 flipOrdering = \ case
@@ -135,6 +141,7 @@ propertyTests =
   , testProperty "t_charIterator_Utf8" t_charIterator_Utf8
   , testProperty "t_quickCheck_isNormalized" t_quickCheck_isNormalized
   , testProperty "t_collate" t_collate
+  , testProperty "t_collate_emptyRule" t_collate_emptyRule
   , testProperty "t_convert" t_convert
   , testProperty "t_blockCode" t_blockCode
   , testProperty "t_charFullName" t_charFullName
@@ -209,6 +216,8 @@ testCases =
     <$> I.numberFormatter "precision-currency-cash currency/EUR" (Locale "it"))
    `ioEq` "12.345,68\160€"
 
+  , Test.HUnit.TestLabel "collate" testCases_collate
+
   ]
   <>
   concat
@@ -225,3 +234,20 @@ testCases =
         ioEq io a = Test.HUnit.TestCase $ do
             x <- io
             x @?= a
+
+
+testCases_collate :: Test.HUnit.Test
+testCases_collate = Test.HUnit.TestList $
+  [ Test.HUnit.TestLabel "invalid format" $
+    assertParseError (I.collatorFrom "& a < <" Nothing Nothing) Err.u_INVALID_FORMAT_ERROR (Just 0) (Just 4)
+  , Test.HUnit.TestLabel "custom collator" $ Test.HUnit.TestCase $ do
+      let Right c = I.collatorFrom "& b < a" Nothing Nothing
+      I.collate c "a" "b" @?= GT
+  ]
+  where
+    assertParseError (Left e) err line offset = Test.HUnit.TestList
+      [ "errError" ~: errError e ~?= err
+      , "errLine" ~: errLine e ~?= line
+      , "errOffset" ~: errOffset e ~?= offset
+      ]
+    assertParseError (Right _) _ _ _ = Test.HUnit.TestCase $ Test.HUnit.assertFailure "Expects a Left"

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -84,7 +84,7 @@ t_collate a b = c a b == flipOrdering (c b a)
 t_collate_emptyRule a b = I.collate cUca a b == I.collate cEmpty a b
   where
     cUca = I.uca
-    Right cEmpty = I.collatorFrom "" Nothing Nothing
+    Right cEmpty = I.collatorFromRules ""
 
 flipOrdering :: Ordering -> Ordering
 flipOrdering = \ case
@@ -239,9 +239,9 @@ testCases =
 testCases_collate :: Test.HUnit.Test
 testCases_collate = Test.HUnit.TestList $
   [ Test.HUnit.TestLabel "invalid format" $
-    assertParseError (I.collatorFrom "& a < <" Nothing Nothing) Err.u_INVALID_FORMAT_ERROR (Just 0) (Just 4)
+    assertParseError (I.collatorFromRules "& a < <") Err.u_INVALID_FORMAT_ERROR (Just 0) (Just 4)
   , Test.HUnit.TestLabel "custom collator" $ Test.HUnit.TestCase $ do
-      let Right c = I.collatorFrom "& b < a" Nothing Nothing
+      let Right c = I.collatorFromRules "& b < a"
       I.collate c "a" "b" @?= GT
   ]
   where


### PR DESCRIPTION
Hi! This PR allows creating collators from custom rules with the following functions that wrap [ucol_openRules()](https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/ucol_8h.html#a0cb1ddd81f322ed24e389f208eb35c8a) and [ucol_getRules()](https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/ucol_8h.html#a47699dcfa9c862b4011aea1927c53d4b).

- `Data.Text.ICU.Collate.openRules :: Text -> Maybe Bool -> Maybe Strength -> IO MCollator`
- `Data.Text.ICU.Collate.Pure.collatorFromRules :: Text -> Either ParseError Collator`
  - Also exposed as `Data.Text.ICU.collatorFromRules`
- `Data.Text.ICU.Collate.Pure.collatorFromRulesWith :: Text -> [IO.Attribute] -> Either ParseError Collator`
  - Also exposed as `Data.Text.ICU.collatorFromRules`
- `Data.Text.ICU.Collate.getRules :: MCollator -> IO Text`
- `Data.Text.ICU.Collate.Pure.rules :: Collator -> Text`

Closes https://github.com/haskell/text-icu/issues/35