### PR TITLE
CI max/win: bump haskell/actions/setup to v2, bump GHC to 9.4.2

### DIFF
--- a/.github/workflows/cabal-mac-win.yml
+++ b/.github/workflows/cabal-mac-win.yml
@@ -16,12 +16,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macOS-latest, windows-latest]
+        os: [macOS-latest]
         ghc:
-          - 8.10.7
-          - 9.0.2
           - 9.2.4
-          - 9.4.2
+        # os: [macOS-latest, windows-latest]
+        # ghc:
+        #   - 8.10.7
+        #   - 9.0.2
+        #   - 9.2.4
+        #   - 9.4.2
             # As of 2022-10-06, haskell/actions/setup does not support 9.4.2 yet.
             # Waiting for https://github.com/haskell/actions/pull/115.
       fail-fast: false
@@ -52,10 +55,15 @@ jobs:
       run: |
         export PKG_CONFIG_PATH=/usr/local/opt/icu4c/lib/pkgconfig
         echo "PKG_CONFIG_PATH=${PKG_CONFIG_PATH}" >> ${GITHUB_ENV}
-        echo "$ ls -l ${PKG_CONFIG_PATH}"
-        ls -l ${PKG_CONFIG_PATH}
+        echo "$ ls -l ${PKG_CONFIG_PATH}/"
+        ls -l ${PKG_CONFIG_PATH}/
         echo "$ pkg-config --modversion icu-i18n"
         pkg-config --modversion icu-i18n
+
+    - name: Check integry of pkg-config database
+      if: ${{ runner.os == 'macOS' }}
+      run: |
+        pkg-config --list-all | cut -f 1 -d ' ' | xargs pkg-config --modversion
 
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/cabal-mac-win.yml
+++ b/.github/workflows/cabal-mac-win.yml
@@ -50,7 +50,12 @@ jobs:
     - name: Set up pkg-config for the ICU library (macOS)
       if: ${{ runner.os == 'macOS' }}
       run: |
-        echo "PKG_CONFIG_PATH=/usr/local/opt/icu4c/lib/pkgconfig" >> ${GITHUB_ENV}
+        export PKG_CONFIG_PATH=/usr/local/opt/icu4c/lib/pkgconfig
+        echo "PKG_CONFIG_PATH=${PKG_CONFIG_PATH}" >> ${GITHUB_ENV}
+        echo "$ ls -l ${PKG_CONFIG_PATH}"
+        ls -l ${PKG_CONFIG_PATH}
+        echo "$ pkg-config --modversion icu-i18n"
+        pkg-config --modversion icu-i18n
 
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/cabal-mac-win.yml
+++ b/.github/workflows/cabal-mac-win.yml
@@ -21,7 +21,7 @@ jobs:
           - 8.10.7
           - 9.0.2
           - 9.2.4
-          - 9.4.1
+          - 9.4.2
             # As of 2022-10-06, haskell/actions/setup does not support 9.4.2 yet.
             # Waiting for https://github.com/haskell/actions/pull/115.
       fail-fast: false
@@ -56,7 +56,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Setup Haskell
-      uses: haskell/actions/setup@v1
+      uses: haskell/actions/setup@v2
       id: setup-haskell-cabal
       with:
         ghc-version: ${{ matrix.ghc }}

--- a/.github/workflows/cabal-mac-win.yml
+++ b/.github/workflows/cabal-mac-win.yml
@@ -59,6 +59,8 @@ jobs:
         ls -l ${PKG_CONFIG_PATH}/
         echo "$ pkg-config --modversion icu-i18n"
         pkg-config --modversion icu-i18n
+        echo "$ pkg-config --libs --static icu-i18n"
+        pkg-config --libs --static icu-i18n
 
     - name: Check integry of pkg-config database
       if: ${{ runner.os == 'macOS' }}

--- a/.github/workflows/cabal-mac-win.yml
+++ b/.github/workflows/cabal-mac-win.yml
@@ -63,6 +63,13 @@ jobs:
     - name: Check integry of pkg-config database
       if: ${{ runner.os == 'macOS' }}
       run: |
+        echo "$ pkg-config --list-all"
+        pkg-config --list-all
+        echo "========================================================================"
+        echo "$ pkg-config --list-all | cut -f 1 -d ' '"
+        pkg-config --list-all | cut -f 1 -d ' '
+        echo "========================================================================"
+        echo "$ pkg-config --list-all | cut -f 1 -d ' ' | xargs pkg-config --modversion"
         pkg-config --list-all | cut -f 1 -d ' ' | xargs pkg-config --modversion
 
     - name: Checkout

--- a/.github/workflows/cabal-mac-win.yml
+++ b/.github/workflows/cabal-mac-win.yml
@@ -16,17 +16,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macOS-latest]
+        os: [macOS-latest, windows-latest]
         ghc:
+          - 8.10.7
+          - 9.0.2
           - 9.2.4
-        # os: [macOS-latest, windows-latest]
-        # ghc:
-        #   - 8.10.7
-        #   - 9.0.2
-        #   - 9.2.4
-        #   - 9.4.2
-            # As of 2022-10-06, haskell/actions/setup does not support 9.4.2 yet.
-            # Waiting for https://github.com/haskell/actions/pull/115.
+          - 9.4.2
       fail-fast: false
 
     env:
@@ -50,6 +45,8 @@ jobs:
     #   run: |
     #     brew install icu4c
 
+    # Let `pkg-config` find the ICU libs.
+    # Also test whether it actually works, and print some debug information.
     - name: Set up pkg-config for the ICU library (macOS)
       if: ${{ runner.os == 'macOS' }}
       run: |
@@ -62,17 +59,20 @@ jobs:
         echo "$ pkg-config --libs --static icu-i18n"
         pkg-config --libs --static icu-i18n
 
-    - name: Check integry of pkg-config database
-      if: ${{ runner.os == 'macOS' }}
-      run: |
-        echo "$ pkg-config --list-all"
-        pkg-config --list-all
-        echo "========================================================================"
-        echo "$ pkg-config --list-all | cut -f 1 -d ' '"
-        pkg-config --list-all | cut -f 1 -d ' '
-        echo "========================================================================"
-        echo "$ pkg-config --list-all | cut -f 1 -d ' ' | xargs pkg-config --modversion"
-        pkg-config --list-all | cut -f 1 -d ' ' | xargs pkg-config --modversion
+    # # Test of `pkg-config --list-all` in connection with macOS-11/12 env bug:
+    # # https://github.com/actions/runner-images/issues/6364
+    # # This was fixed upstream 2022-10-10.
+    # - name: Check integrity of pkg-config database
+    #   if: ${{ runner.os == 'macOS' }}
+    #   run: |
+    #     echo "$ pkg-config --list-all"
+    #     pkg-config --list-all
+    #     echo "========================================================================"
+    #     echo "$ pkg-config --list-all | cut -f 1 -d ' '"
+    #     pkg-config --list-all | cut -f 1 -d ' '
+    #     echo "========================================================================"
+    #     echo "$ pkg-config --list-all | cut -f 1 -d ' ' | xargs pkg-config --modversion"
+    #     pkg-config --list-all | cut -f 1 -d ' ' | xargs pkg-config --modversion
 
     - name: Checkout
       uses: actions/checkout@v3


### PR DESCRIPTION
This bumps the mac/win CI to the latest versions.  Closes #80.

Ran into 
- https://github.com/actions/runner-images/issues/6364 

which is fixed since 2022-10-10.  Kept code that prints useful debugging info around `pkg-config`.

The individual commits are not meaningful, need to be __SQUASHED__.