### PR TITLE
README: make PKG_CONFIG_PATH portable on macOS

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -25,7 +25,7 @@ be installed separately).
 
 You might need:
 
-    export PKG_CONFIG_PATH="/usr/local/opt/icu4c/lib/pkgconfig"
+    export PKG_CONFIG_PATH="$(brew --prefix)/opt/icu4c/lib/pkgconfig"
 
 ### Debian/Ubuntu
 


### PR DESCRIPTION
Different macOS architectures have different homebrew install locations, it can be either `/usr/local`  or `/opt/homebrew`.   The correct location is obtained via `brew --prefix`.