### PR TITLE
Bump CI to GHC 9.4.4 9.2.5; use $(brew --prefix) for PKG_CONFIG_PATH

### DIFF
--- a/.github/workflows/cabal-mac-win.yml
+++ b/.github/workflows/cabal-mac-win.yml
@@ -20,8 +20,8 @@ jobs:
         ghc:
           - 8.10.7
           - 9.0.2
-          - 9.2.4
-          - 9.4.2
+          - 9.2.5
+          - 9.4.4
       fail-fast: false
 
     env:
@@ -50,7 +50,7 @@ jobs:
     - name: Set up pkg-config for the ICU library (macOS)
       if: ${{ runner.os == 'macOS' }}
       run: |
-        export PKG_CONFIG_PATH=/usr/local/opt/icu4c/lib/pkgconfig
+        export PKG_CONFIG_PATH=$(brew --prefix)/opt/icu4c/lib/pkgconfig
         echo "PKG_CONFIG_PATH=${PKG_CONFIG_PATH}" >> ${GITHUB_ENV}
         echo "$ ls -l ${PKG_CONFIG_PATH}/"
         ls -l ${PKG_CONFIG_PATH}/

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.15.20220826
+# version: 0.15.20230115
 #
-# REGENDATA ("0.15.20220826",["github","text-icu.cabal"])
+# REGENDATA ("0.15.20230115",["github","text-icu.cabal"])
 #
 name: Haskell-CI
 on:
@@ -34,14 +34,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.4.2
+          - compiler: ghc-9.4.4
             compilerKind: ghc
-            compilerVersion: 9.4.2
+            compilerVersion: 9.4.4
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.2.4
+          - compiler: ghc-9.2.5
             compilerKind: ghc
-            compilerVersion: 9.2.4
+            compilerVersion: 9.2.5
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2
@@ -186,7 +186,7 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -222,7 +222,7 @@ jobs:
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dry-run all
           cabal-plan
       - name: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store

--- a/text-icu.cabal
+++ b/text-icu.cabal
@@ -59,8 +59,8 @@ tested-with:
   GHC == 8.8.4
   GHC == 8.10.7
   GHC == 9.0.2
-  GHC == 9.2.4
-  GHC == 9.4.2
+  GHC == 9.2.5
+  GHC == 9.4.4
 
 library
   default-language:  Haskell98


### PR DESCRIPTION
Bump CI to GHC 9.4.4 and 9.2.5.
Use `$(brew --prefix)` for `PKG_CONFIG_PATH`, cf:
- #84
