### PR TITLE
CI maintenance: GHC 9.6, caching under Windows

### DIFF
--- a/.github/workflows/cabal-mac-win.yml
+++ b/.github/workflows/cabal-mac-win.yml
@@ -24,9 +24,6 @@ jobs:
           - 9.4.4
       fail-fast: false
 
-    env:
-      config: --enable-tests --test-show-details=direct
-
     steps:
 
     # Andreas, 2023-02-12:
@@ -84,6 +81,13 @@ jobs:
     #     echo "$ pkg-config --list-all | cut -f 1 -d ' ' | xargs pkg-config --modversion"
     #     pkg-config --list-all | cut -f 1 -d ' ' | xargs pkg-config --modversion
 
+    - name: Determine the ICU version
+      shell: bash
+      run: |
+        ICU_VER=$(pkg-config --modversion icu-i18n)
+        echo "ICU_VER=${ICU_VER}"
+        echo "ICU_VER=${ICU_VER}" >> "${GITHUB_ENV}"
+
     - name: Checkout
       uses: actions/checkout@v3
 
@@ -93,9 +97,11 @@ jobs:
       with:
         ghc-version: ${{ matrix.ghc }}
 
-    - name: Freeze
+    - name: Configure
       run: |
-        cabal freeze
+        cabal configure --enable-tests
+        cabal build --dry-run
+      # cabal build --dry-run creates dist-newstyle/cache/plan.json
 
     - name: Cache ~/.cabal/store
       uses: actions/cache@v3
@@ -103,13 +109,13 @@ jobs:
         path: |
           ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
           dist-newstyle
-        key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
+        key:          ${{ runner.os }}-ghc-${{ matrix.ghc }}-icu-${{ env.ICU_VER }}-plan-${{ hashFiles('dist-newstyle/cache/plan.json') }}
+        restore-keys: ${{ runner.os }}-ghc-${{ matrix.ghc }}-icu-${{ env.ICU_VER }}-
 
     - name: Build
       run: |
-        cabal configure ${{ env.config }}
         cabal build all
 
     - name: Test
       run: |
-        cabal test all ${{ env.config }}
+        cabal test all --test-show-details=direct

--- a/.github/workflows/cabal-mac-win.yml
+++ b/.github/workflows/cabal-mac-win.yml
@@ -29,18 +29,26 @@ jobs:
 
     steps:
 
-    - name: Setup MSYS path
+    # Andreas, 2023-02-12:
+    # Putting the MSYS2 /usr/bin (and thus 'tar') into the PATH destroys the Cache action v3.
+    # See: https://github.com/actions/cache/issues/1073
+    # However the /mingw64/bin PATH for the MSYS2-installed 'pkg-config' is fine.
+    #
+    - name: Setup MSYS path for pkg-config
       if: ${{ runner.os == 'Windows' }}
       run: |
-        echo "C:\msys64\mingw64\bin;C:\msys64\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Append
+        echo "C:\msys64\mingw64\bin" | Out-File -FilePath "$env:GITHUB_PATH" -Append
 
     - name: Install the ICU library (Windows)
       if: ${{ runner.os == 'Windows' }}
+      shell: pwsh
+        ## Even though pwsh is default for windows, keep this for sake of actionlint/shellcheck!
       run: |
+        $env:PATH = "C:\msys64\usr\bin;$env:PATH"
         pacman --noconfirm -S mingw-w64-x86_64-pkg-config mingw-w64-x86_64-icu
 
     # Installing ICU is not necessary, macOS-latest already has v69.1
-    # - name: Install the ICU library
+    # - name: Install the ICU library (macOS)
     #   shell: bash
     #   run: |
     #     brew install icu4c

--- a/.github/workflows/cabal-mac-win.yml
+++ b/.github/workflows/cabal-mac-win.yml
@@ -50,10 +50,12 @@ jobs:
     - name: Set up pkg-config for the ICU library (macOS)
       if: ${{ runner.os == 'macOS' }}
       run: |
-        export PKG_CONFIG_PATH=$(brew --prefix)/opt/icu4c/lib/pkgconfig
-        echo "PKG_CONFIG_PATH=${PKG_CONFIG_PATH}" >> ${GITHUB_ENV}
+        PKG_CONFIG_PATH=$(brew --prefix)/opt/icu4c/lib/pkgconfig
+        echo "PKG_CONFIG_PATH=${PKG_CONFIG_PATH}" >> "${GITHUB_ENV}"
+        ## The rest is debug info:
         echo "$ ls -l ${PKG_CONFIG_PATH}/"
-        ls -l ${PKG_CONFIG_PATH}/
+        ls -l "${PKG_CONFIG_PATH}/"
+        export PKG_CONFIG_PATH
         echo "$ pkg-config --modversion icu-i18n"
         pkg-config --modversion icu-i18n
         echo "$ pkg-config --libs --static icu-i18n"

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.15.20230115
+# version: 0.15.20230203
 #
-# REGENDATA ("0.15.20230115",["github","text-icu.cabal"])
+# REGENDATA ("0.15.20230203",["github","text-icu.cabal"])
 #
 name: Haskell-CI
 on:
@@ -34,6 +34,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.6.0.20230128
+            compilerKind: ghc
+            compilerVersion: 9.6.0.20230128
+            setup-method: ghcup
+            allow-failure: true
           - compiler: ghc-9.4.4
             compilerKind: ghc
             compilerVersion: 9.4.4
@@ -94,8 +99,9 @@ jobs:
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.9.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           else
             apt-add-repository -y 'ppa:hvr/ghc'
             apt-get update
@@ -103,7 +109,8 @@ jobs:
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.9.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -121,20 +128,20 @@ jobs:
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
             echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.9.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           else
             HC=$HCDIR/bin/$HCKIND
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
             echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.9.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           fi
 
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 90600)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -163,6 +170,18 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
+          EOF
+          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -214,6 +233,9 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(binary|bytestring|containers|deepseq|directory|text-icu|time|unix)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
@@ -221,8 +243,8 @@ jobs:
         run: |
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dry-run all
           cabal-plan
-      - name: cache
-        uses: actions/cache@v3
+      - name: restore cache
+        uses: actions/cache/restore@v3
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store
@@ -246,8 +268,14 @@ jobs:
           ${CABAL} -vnormal check
       - name: haddock
         run: |
-          $CABAL v2-haddock --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
+          $CABAL v2-haddock --disable-documentation --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
       - name: unconstrained build
         run: |
           rm -f cabal.project.local
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
+      - name: save cache
+        uses: actions/cache/save@v3
+        if: always()
+        with:
+          key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
+          path: ~/.cabal/store

--- a/text-icu.cabal
+++ b/text-icu.cabal
@@ -1,3 +1,5 @@
+cabal-version:  1.18
+  -- 1.18 introduced extra-doc-files
 name:           text-icu
 version:        0.8.0.2
 synopsis:       Bindings to the ICU library
@@ -43,11 +45,13 @@ category:       Data, Text
 license:        BSD3
 license-file:   LICENSE
 build-type:     Simple
-cabal-version:  >= 1.10
-extra-source-files:
+
+extra-doc-files:
   README.markdown
-  benchmarks/Breaker.hs
   changelog.md
+
+extra-source-files:
+  benchmarks/Breaker.hs
   include/hs_text_icu.h
 
 tested-with:
@@ -66,12 +70,13 @@ tested-with:
 library
   default-language:  Haskell98
   build-depends:
-    base >= 4.8 && < 5,
+    base        >= 4.8      && < 5,
     bytestring,
-    deepseq >= 1.4.2.0,
-    text >=0.9.1.0 && <1.3 || >=2.0 && <2.1,
-    time >=1.5 && <1.13
-  pkgconfig-depends: icu-i18n >= 62.1
+    deepseq     >= 1.4.2.0,
+    text        >= 0.9.1.0  && < 1.3  || >= 2.0 && < 2.1,
+    time        >= 1.5      && < 1.13
+  pkgconfig-depends:
+    icu-i18n    >= 62.1
 
   exposed-modules:
       Data.Text.ICU
@@ -129,7 +134,7 @@ library
   else
     extra-libraries: icui18n icudata
 
-  ghc-options: -Wall -fwarn-tabs
+  ghc-options: -Wall
   if impl(ghc >= 8.0)
     ghc-options:  -Wcompat
 

--- a/text-icu.cabal
+++ b/text-icu.cabal
@@ -51,16 +51,17 @@ extra-source-files:
   include/hs_text_icu.h
 
 tested-with:
-  GHC == 7.10.3
-  GHC == 8.0.2
-  GHC == 8.2.2
-  GHC == 8.4.4
-  GHC == 8.6.5
-  GHC == 8.8.4
-  GHC == 8.10.7
-  GHC == 9.0.2
-  GHC == 9.2.5
+  GHC == 9.6.0
   GHC == 9.4.4
+  GHC == 9.2.5
+  GHC == 9.0.2
+  GHC == 8.10.7
+  GHC == 8.8.4
+  GHC == 8.6.5
+  GHC == 8.4.4
+  GHC == 8.2.2
+  GHC == 8.0.2
+  GHC == 7.10.3
 
 library
   default-language:  Haskell98


### PR DESCRIPTION
Address issue of the cache action under Windows:
- https://github.com/actions/cache/issues/1073
- workaround: do not add MSYS2 /usr/bin to PATH, as it the cache action gets confused about `tar` then
- improve cache key to include ICU version
- don't use freeze file in cache key (as it contains time stamps), rather use `plan.json`
 
Include GHC 9.6.1 alpha2 in Haskell CI.

Some overhaul of the `.cabal` file (mostly cosmetic).
- Bump to `cabal-version: 1.18` to use `extra-doc-files` field.
- Remove redundant `-fwarn-tabs` (included in `-Wall`).
- Formatting the dependencies.

NB: Since CI does not run often here, most caches anyway get deleted (after a week) rather than reused.  
However, I want to set a good example with a good caching logic.