### PR TITLE
Make homebrew optional

### DIFF
--- a/text-icu.cabal
+++ b/text-icu.cabal
@@ -46,6 +46,11 @@ license:        BSD3
 license-file:   LICENSE
 build-type:     Simple
 
+flag homebrew
+  Description: Assume homebrew on macOS. Automatically add /usr/local/opt/ and /usr/homebrew/opt/ paths to extra-lib-dirs and include-dirs.
+  Default:     True
+  Manual:      True
+
 extra-doc-files:
   README.markdown
   changelog.md
@@ -122,7 +127,7 @@ library
   c-sources: cbits/text_icu.c
   cc-options: -Wall -Wextra -pedantic -Wno-deprecated
   include-dirs: include
-  if os(darwin)
+  if os(darwin) && flag(homebrew)
     extra-lib-dirs:
       /usr/local/opt/icu4c/lib
       /opt/homebrew/opt/icu4c/lib


### PR DESCRIPTION
Force-adding homebrew paths to `text-icu`, causes compilation and link errors on systems that have a mixture of homebrew and other system library providers. There currently is no way to prohibit `text-icu` from _not_ force-injecting homebrew paths. 

This change adds a flag to allow disabling the forced addition of homebrew paths to the package description.

Morally I'd argue that this flag should be off by default, I do however see this as a harder case to argue, and the current on-by-default to be less contentious.