### PR TITLE
Bump CI to macos-14 runner

### DIFF
--- a/.github/workflows/cabal-mac-win.yml
+++ b/.github/workflows/cabal-mac-win.yml
@@ -3,11 +3,9 @@ on:
   push:
     branches:
     - master
-    - ci-*
   pull_request:
     branches:
     - master
-    - ci-*
 
 jobs:
 
@@ -18,10 +16,10 @@ jobs:
       matrix:
         os: [macOS-latest, windows-latest]
         ghc:
-          - 9.0.2
           - 9.2.8
-          - 9.4.7
-          - 9.6.2
+          - 9.4.8
+          - 9.6.5
+          - 9.8.2
       fail-fast: false
 
     steps:

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/andreasabel/haskell-ci
 #
-# version: 0.19.20240403
+# version: 0.19.20240429
 #
-# REGENDATA ("0.19.20240403",["github","text-icu.cabal"])
+# REGENDATA ("0.19.20240429",["github","text-icu.cabal"])
 #
 name: Haskell-CI
 on:
@@ -27,14 +27,14 @@ jobs:
     timeout-minutes:
       60
     container:
-      image: buildpack-deps:focal
+      image: buildpack-deps:jammy
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.10.0.20240328
+          - compiler: ghc-9.10.0.20240426
             compilerKind: ghc
-            compilerVersion: 9.10.0.20240328
+            compilerVersion: 9.10.0.20240426
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.8.2
@@ -42,9 +42,9 @@ jobs:
             compilerVersion: 9.8.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.6.4
+          - compiler: ghc-9.6.5
             compilerKind: ghc
-            compilerVersion: 9.6.4
+            compilerVersion: 9.6.5
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.4.8

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -17,7 +17,7 @@ defaults:
 
 jobs:
   stack:
-    name: ${{ matrix.os }} Stack ${{ matrix.plan.resolver }} / ${{ matrix.plan.ghc }}
+    name: ${{ matrix.os }} Stack ${{ matrix.plan.resolver }}
     strategy:
       fail-fast: false
       matrix:
@@ -32,6 +32,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+
+    - uses: haskell-actions/setup@v2
+      with:
+        enable-stack: true
+        stack-no-global: true
 
     - name: Configure
       run: |
@@ -53,7 +58,7 @@ jobs:
       # echo "STACK_ROOT=${STACK_ROOT}" >> "${GITHUB_ENV}"
 
     - name: Set up for the ICU library (macOS)
-      if: ${{ runner.os == 'macOS' }}
+      if: runner.os == 'macOS'
       run: |
         ICU4C=$(brew --prefix)/opt/icu4c
         echo "PKG_CONFIG_PATH=${ICU4C}/lib/pkgconfig" >> "${GITHUB_ENV}"

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -3,7 +3,7 @@
 branches: master
 
 -- text-icu-0.8 requires a newer ICU lib (shipped not with Ubuntu 18.04, but with 20.04)
-distribution: focal
+-- distribution: focal
 
 -- installed: +all -binary -bytestring -containers -deepseq -directory -time -unix
 

--- a/text-icu.cabal
+++ b/text-icu.cabal
@@ -57,7 +57,7 @@ extra-source-files:
 tested-with:
   GHC == 9.10.0
   GHC == 9.8.2
-  GHC == 9.6.4
+  GHC == 9.6.5
   GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2


### PR DESCRIPTION
- **Bump Haskell CI to jammy distribution**
- **CI mac: drop GHC 9.0 (not supported by macos-latest)**
