### PR TITLE
Remove obsolete deriving Typeable also from .hsc files

### DIFF
--- a/Data/Text/ICU/CaseMap.hsc
+++ b/Data/Text/ICU/CaseMap.hsc
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable, EmptyDataDecls, ForeignFunctionInterface #-}
+{-# LANGUAGE EmptyDataDecls, ForeignFunctionInterface #-}
 -- |
 -- Module      : Data.Text.ICU.CaseMap
 -- Copyright   : (c) 2010 Bryan O'Sullivan
@@ -26,7 +26,6 @@ import Data.Bits ((.|.))
 import Data.List (foldl')
 import Data.Text.ICU.Error.Internal (UErrorCode, handleError)
 import Data.Text.ICU.Internal (LocaleName, withLocaleName)
-import Data.Typeable (Typeable)
 import Data.Word (Word32)
 import Foreign.C.String (CString)
 import Foreign.ForeignPtr (ForeignPtr)
@@ -36,7 +35,7 @@ import System.IO.Unsafe (unsafePerformIO)
 data UCaseMap
 
 data CaseMap = CaseMap {-# UNPACK #-} !(ForeignPtr UCaseMap)
-               deriving (Eq, Typeable)
+               deriving (Eq)
 
 data CaseOption = FoldCaseExcludeSpecialI
                 | TitleCaseNoLowerCase

--- a/Data/Text/ICU/Char.hsc
+++ b/Data/Text/ICU/Char.hsc
@@ -1,4 +1,4 @@
-{-# LANGUAGE BangPatterns, DeriveDataTypeable, FlexibleInstances,
+{-# LANGUAGE BangPatterns, FlexibleInstances,
     ForeignFunctionInterface, FunctionalDependencies, MultiParamTypeClasses #-}
 
 -- |
@@ -93,7 +93,6 @@ import Data.Text.ICU.Error (u_INVALID_CHAR_FOUND)
 import Data.Text.ICU.Error.Internal (UErrorCode, handleOverflowError, withError)
 import Data.Text.ICU.Internal (UBool, UChar32, asBool)
 import Data.Text.ICU.Normalize.Internal (toNCR)
-import Data.Typeable (Typeable)
 import Data.Word (Word8)
 import Foreign.C.String (CString, peekCStringLen, withCString)
 import Foreign.C.Types (CInt(..))
@@ -135,7 +134,7 @@ data Direction =
   | LeftToRightIsolate
   | RightToLeftIsolate
   | PopDirectionalIsolate
-  deriving (Eq, Enum, Show, Typeable)
+  deriving (Eq, Enum, Show)
 
 instance NFData Direction where
     rnf !_ = ()
@@ -492,7 +491,7 @@ data BlockCode =
   | Kawi
   | NagMundari
 
-  deriving (Eq, Enum, Bounded, Show, Typeable)
+  deriving (Eq, Enum, Bounded, Show)
 
 instance NFData BlockCode where
     rnf !_ = ()
@@ -636,7 +635,7 @@ data Bool_ =
   | RgiEmojiTagSequence -- ^ See https://www.unicode.org/reports/tr51/#Emoji_Sets
   | RgiEmojiZwjSequence -- ^ See https://www.unicode.org/reports/tr51/#Emoji_Sets
   | RgiEmoji -- ^ See https://www.unicode.org/reports/tr51/#Emoji_Sets
-  deriving (Eq, Enum, Show, Typeable)
+  deriving (Eq, Enum, Show)
 
 instance NFData Bool_ where
     rnf !_ = ()
@@ -645,7 +644,7 @@ class Property p v | p -> v where
     fromNative :: p -> Int32 -> v
     toUProperty :: p -> UProperty
 
-data BidiClass_ = BidiClass deriving (Show, Typeable)
+data BidiClass_ = BidiClass deriving (Show)
 
 instance NFData BidiClass_ where
     rnf !_ = ()
@@ -663,7 +662,7 @@ instance Property Block_ BlockCode where
     fromNative _  = toEnum . fromIntegral
     toUProperty _ = (#const UCHAR_BLOCK)
 
-data CanonicalCombiningClass_ = CanonicalCombiningClass deriving (Show,Typeable)
+data CanonicalCombiningClass_ = CanonicalCombiningClass deriving (Show)
 
 instance NFData CanonicalCombiningClass_ where
     rnf !_ = ()
@@ -672,7 +671,7 @@ instance Property CanonicalCombiningClass_ Int where
     fromNative _  = fromIntegral
     toUProperty _ = (#const UCHAR_CANONICAL_COMBINING_CLASS)
 
-data Decomposition_ = Decomposition deriving (Show, Typeable)
+data Decomposition_ = Decomposition deriving (Show)
 
 instance NFData Decomposition_ where
     rnf !_ = ()
@@ -696,7 +695,7 @@ data Decomposition =
   | Vertical
   | Wide
   | Count
-    deriving (Eq, Enum, Show, Typeable)
+    deriving (Eq, Enum, Show)
 
 instance NFData Decomposition where
     rnf !_ = ()
@@ -705,7 +704,7 @@ instance Property Decomposition_ (Maybe Decomposition) where
     fromNative _  = maybeEnum
     toUProperty _ = (#const UCHAR_DECOMPOSITION_TYPE)
 
-data EastAsianWidth_ = EastAsianWidth deriving (Show, Typeable)
+data EastAsianWidth_ = EastAsianWidth deriving (Show)
 
 instance NFData EastAsianWidth_ where
     rnf !_ = ()
@@ -717,7 +716,7 @@ data EastAsianWidth = EANeutral
                     | EANarrow
                     | EAWide
                     | EACount
-                    deriving (Eq, Enum, Show, Typeable)
+                    deriving (Eq, Enum, Show)
 
 instance NFData EastAsianWidth where
     rnf !_ = ()
@@ -730,7 +729,7 @@ instance Property Bool_ Bool where
     fromNative _ = (/=0)
     toUProperty  = fromIntegral . fromEnum
 
-data GeneralCategory_ = GeneralCategory deriving (Show, Typeable)
+data GeneralCategory_ = GeneralCategory deriving (Show)
 
 instance NFData GeneralCategory_ where
     rnf !_ = ()
@@ -766,7 +765,7 @@ data GeneralCategory =
   | OtherSymbol
   | InitialPunctuation
   | FinalPunctuation
-    deriving (Eq, Enum, Show, Typeable)
+    deriving (Eq, Enum, Show)
 
 instance NFData GeneralCategory where
     rnf !_ = ()
@@ -775,7 +774,7 @@ instance Property GeneralCategory_ GeneralCategory where
     fromNative _  = toEnum . fromIntegral
     toUProperty _ = (#const UCHAR_GENERAL_CATEGORY)
 
-data JoiningGroup_ = JoiningGroup deriving (Show, Typeable)
+data JoiningGroup_ = JoiningGroup deriving (Show)
 
 instance NFData JoiningGroup_ where
     rnf !_ = ()
@@ -870,7 +869,7 @@ data JoiningGroup =
   | ManichaeanYodh
   | ManichaeanZayin
   | StraightWaw
-    deriving (Eq, Enum, Show, Typeable)
+    deriving (Eq, Enum, Show)
 
 instance NFData JoiningGroup where
     rnf !_ = ()
@@ -879,7 +878,7 @@ instance Property JoiningGroup_ (Maybe JoiningGroup) where
     fromNative _  = maybeEnum
     toUProperty _ = (#const UCHAR_JOINING_GROUP)
 
-data JoiningType_ = JoiningType deriving (Show, Typeable)
+data JoiningType_ = JoiningType deriving (Show)
 
 instance NFData JoiningType_ where
     rnf !_ = ()
@@ -890,7 +889,7 @@ data JoiningType =
   | LeftJoining
   | RightJoining
   | Transparent
-    deriving (Eq, Enum, Show, Typeable)
+    deriving (Eq, Enum, Show)
 
 instance NFData JoiningType where
     rnf !_ = ()
@@ -899,7 +898,7 @@ instance Property JoiningType_ (Maybe JoiningType) where
     fromNative _  = maybeEnum
     toUProperty _ = (#const UCHAR_JOINING_TYPE)
 
-data LineBreak_ = LineBreak deriving (Show, Typeable)
+data LineBreak_ = LineBreak deriving (Show)
 
 instance NFData LineBreak_ where
     rnf !_ = ()
@@ -947,7 +946,7 @@ data LineBreak =
   | EBase
   | EModifier
   | ZWJ
-    deriving (Eq, Enum, Show, Typeable)
+    deriving (Eq, Enum, Show)
 
 instance NFData LineBreak where
     rnf !_ = ()
@@ -956,13 +955,13 @@ instance Property LineBreak_ (Maybe LineBreak) where
     fromNative _  = maybeEnum
     toUProperty _ = (#const UCHAR_LINE_BREAK)
 
-data NumericType_ = NumericType deriving (Show, Typeable)
+data NumericType_ = NumericType deriving (Show)
 
 instance NFData NumericType_ where
     rnf !_ = ()
 
 data NumericType = NTDecimal | NTDigit | NTNumeric
-                   deriving (Eq, Enum, Show, Typeable)
+                   deriving (Eq, Enum, Show)
 
 instance NFData NumericType where
     rnf !_ = ()
@@ -971,7 +970,7 @@ instance Property NumericType_ (Maybe NumericType) where
     fromNative _  = maybeEnum
     toUProperty _ = (#const UCHAR_NUMERIC_TYPE)
 
-data HangulSyllableType_ = HangulSyllableType deriving (Show, Typeable)
+data HangulSyllableType_ = HangulSyllableType deriving (Show)
 
 instance NFData HangulSyllableType_ where
     rnf !_ = ()
@@ -982,7 +981,7 @@ data HangulSyllableType =
   | TrailingJamo
   | LVSyllable
   | LVTSyllable
-    deriving (Eq, Enum, Show, Typeable)
+    deriving (Eq, Enum, Show)
 
 instance NFData HangulSyllableType where
     rnf !_ = ()
@@ -991,10 +990,10 @@ instance Property HangulSyllableType_ (Maybe HangulSyllableType) where
     fromNative _  = maybeEnum
     toUProperty _ = (#const UCHAR_HANGUL_SYLLABLE_TYPE)
 
-data NFCQuickCheck_ = NFCQuickCheck deriving (Show, Typeable)
-data NFDQuickCheck_ = NFDQuickCheck deriving (Show, Typeable)
-data NFKCQuickCheck_ = NFKCQuickCheck deriving (Show, Typeable)
-data NFKDQuickCheck_ = NFKDQuickCheck deriving (Show, Typeable)
+data NFCQuickCheck_ = NFCQuickCheck deriving (Show)
+data NFDQuickCheck_ = NFDQuickCheck deriving (Show)
+data NFKCQuickCheck_ = NFKCQuickCheck deriving (Show)
+data NFKDQuickCheck_ = NFKDQuickCheck deriving (Show)
 
 instance NFData NFCQuickCheck_ where
     rnf !_ = ()
@@ -1025,7 +1024,7 @@ instance Property NFKDQuickCheck_ (Maybe Bool) where
     toUProperty _ = (#const UCHAR_NFKD_QUICK_CHECK)
 
 data LeadCanonicalCombiningClass_ = LeadCanonicalCombiningClass
-                                    deriving (Show, Typeable)
+                                    deriving (Show)
 
 instance NFData LeadCanonicalCombiningClass_ where
     rnf !_ = ()
@@ -1035,7 +1034,7 @@ instance Property LeadCanonicalCombiningClass_ Int where
     toUProperty _ = (#const UCHAR_LEAD_CANONICAL_COMBINING_CLASS)
 
 data TrailingCanonicalCombiningClass_ = TrailingCanonicalCombiningClass
-                                   deriving (Show, Typeable)
+                                   deriving (Show)
 
 instance NFData TrailingCanonicalCombiningClass_ where
     rnf !_ = ()
@@ -1044,7 +1043,7 @@ instance Property TrailingCanonicalCombiningClass_ Int where
     fromNative  _ = fromIntegral
     toUProperty _ = (#const UCHAR_TRAIL_CANONICAL_COMBINING_CLASS)
 
-data GraphemeClusterBreak_ = GraphemeClusterBreak deriving (Show, Typeable)
+data GraphemeClusterBreak_ = GraphemeClusterBreak deriving (Show)
 
 instance NFData GraphemeClusterBreak_ where
     rnf !_ = ()
@@ -1067,7 +1066,7 @@ data GraphemeClusterBreak =
   | GCBEModifier
   | GCBGlueAfterZWJ
   | GCBZWJ
-    deriving (Eq, Enum, Show, Typeable)
+    deriving (Eq, Enum, Show)
 
 instance NFData GraphemeClusterBreak where
     rnf !_ = ()
@@ -1076,7 +1075,7 @@ instance Property GraphemeClusterBreak_ (Maybe GraphemeClusterBreak) where
     fromNative  _ = maybeEnum
     toUProperty _ = (#const UCHAR_GRAPHEME_CLUSTER_BREAK)
 
-data SentenceBreak_ = SentenceBreak deriving (Show, Typeable)
+data SentenceBreak_ = SentenceBreak deriving (Show)
 
 instance NFData SentenceBreak_ where
     rnf !_ = ()
@@ -1096,7 +1095,7 @@ data SentenceBreak =
   | SBExtend
   | SBLF
   | SBSContinue
-    deriving (Eq, Enum, Show, Typeable)
+    deriving (Eq, Enum, Show)
 
 instance NFData SentenceBreak where
     rnf !_ = ()
@@ -1105,7 +1104,7 @@ instance Property SentenceBreak_ (Maybe SentenceBreak) where
     fromNative  _ = maybeEnum
     toUProperty _ = (#const UCHAR_SENTENCE_BREAK)
 
-data WordBreak_ = WordBreak deriving (Show, Typeable)
+data WordBreak_ = WordBreak deriving (Show)
 
 instance NFData WordBreak_ where
     rnf !_ = ()
@@ -1127,7 +1126,7 @@ data WordBreak =
   | WBHebrewLetter
   | WBSingleQuote
   | WBDoubleQuote
-    deriving (Eq, Enum, Show, Typeable)
+    deriving (Eq, Enum, Show)
 
 instance NFData WordBreak where
     rnf !_ = ()
@@ -1136,7 +1135,7 @@ instance Property WordBreak_ (Maybe WordBreak) where
     fromNative  _ = maybeEnum
     toUProperty _ = (#const UCHAR_WORD_BREAK)
 
-data BidiPairedBracketType_ = BidiPairedBracketType deriving (Show, Typeable)
+data BidiPairedBracketType_ = BidiPairedBracketType deriving (Show)
 
 instance NFData BidiPairedBracketType_ where
     rnf !_ = ()
@@ -1145,7 +1144,7 @@ data BidiPairedBracketType =
     BPTNone
   | BPTOpen
   | BPTClose
-    deriving (Eq, Enum, Show, Typeable)
+    deriving (Eq, Enum, Show)
 
 instance NFData BidiPairedBracketType where
     rnf !_ = ()

--- a/Data/Text/ICU/CharsetDetection/Internal.hsc
+++ b/Data/Text/ICU/CharsetDetection/Internal.hsc
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable, ForeignFunctionInterface, EmptyDataDecls #-}
+{-# LANGUAGE ForeignFunctionInterface, EmptyDataDecls #-}
 -- |
 -- Module      : Data.Text.ICU.CharsetDetection.Internal
 -- Copyright   : (c) 2017 Zac Slade
@@ -27,7 +27,6 @@ module Data.Text.ICU.CharsetDetection.Internal
     , withCharsetMatch
     ) where
 
-import Data.Typeable (Typeable)
 import Foreign.ForeignPtr (ForeignPtr, withForeignPtr)
 import Foreign.Ptr (FunPtr, Ptr)
 
@@ -45,7 +44,7 @@ data UCharsetDetector
 -- management of the pointers.
 data CharsetDetector = CharsetDetector {
     charsetDetectorPtr :: {-# UNPACK #-} !(ForeignPtr UCharsetDetector)
-} deriving (Typeable)
+}
 
 mkCharsetDetector :: IO CharsetDetector
 mkCharsetDetector = wrapUCharsetDetector $ handleError ucsdet_open
@@ -75,7 +74,6 @@ data CharsetMatch =
     -- ^ keep reference since UCharsetMatch object is owned
     -- by the UCharsetDetector.
     }
-    deriving (Typeable)
 
 wrapUCharsetMatch :: CharsetDetector -> IO (Ptr UCharsetMatch) -> IO CharsetMatch
 wrapUCharsetMatch cd = fmap $ flip CharsetMatch cd

--- a/Data/Text/ICU/Collate.hsc
+++ b/Data/Text/ICU/Collate.hsc
@@ -1,4 +1,4 @@
-{-# LANGUAGE BangPatterns, CPP, DeriveDataTypeable, ForeignFunctionInterface #-}
+{-# LANGUAGE BangPatterns, CPP, ForeignFunctionInterface #-}
 -- |
 -- Module      : Data.Text.ICU.Collate
 -- Copyright   : (c) 2010 Bryan O'Sullivan
@@ -52,7 +52,6 @@ import Data.Text.ICU.Error.Internal (UErrorCode, UParseError, handleError, handl
 import Data.Text.ICU.Internal
     (LocaleName, UChar, CharIterator, UCharIterator,
      asOrdering, fromUCharPtr, withCharIterator, withLocaleName, useAsUCharPtr)
-import Data.Typeable (Typeable)
 import Data.Word (Word8)
 import Foreign.C.String (CString)
 import Foreign.C.Types (CInt(..))
@@ -74,7 +73,7 @@ data AlternateHandling = NonIgnorable
                          -- equal to or below the variable top value to be
                          -- ignored on primary level and moved to the
                          -- quaternary level.
-                         deriving (Eq, Bounded, Enum, Show, Typeable)
+                         deriving (Eq, Bounded, Enum, Show)
 
 instance NFData AlternateHandling where
     rnf !_ = ()
@@ -84,7 +83,7 @@ data CaseFirst = UpperFirst     -- ^ Force upper case letters to sort before
                                 -- lower case.
                | LowerFirst     -- ^ Force lower case letters to sort before
                                 -- upper case.
-                deriving (Eq, Bounded, Enum, Show, Typeable)
+                deriving (Eq, Bounded, Enum, Show)
 
 instance NFData CaseFirst where
     rnf !_ = ()
@@ -102,7 +101,7 @@ data Strength = Primary
               | Tertiary
               | Quaternary
               | Identical
-                deriving (Eq, Bounded, Enum, Show, Typeable)
+                deriving (Eq, Bounded, Enum, Show)
 
 instance NFData Strength where
     rnf !_ = ()
@@ -147,7 +146,7 @@ data Attribute = French Bool
                  -- ^ When enabled, this attribute generates a collation key
                  -- for the numeric value of substrings of digits.  This is
                  -- a way to get '100' to sort /after/ '2'.
-                 deriving (Eq, Show, Typeable)
+                 deriving (Eq, Show)
 
 instance NFData Attribute where
     rnf (French !_)                 = ()

--- a/Data/Text/ICU/Error/Internal.hsc
+++ b/Data/Text/ICU/Error/Internal.hsc
@@ -1,4 +1,4 @@
-{-# LANGUAGE BangPatterns, DeriveDataTypeable, ForeignFunctionInterface,
+{-# LANGUAGE BangPatterns, ForeignFunctionInterface,
     RecordWildCards, ScopedTypeVariables #-}
 
 module Data.Text.ICU.Error.Internal
@@ -28,7 +28,6 @@ import Foreign.Marshal.Alloc (alloca, allocaBytes)
 import Foreign.Marshal.Utils (with)
 import Foreign.Marshal.Array (allocaArray)
 import Data.Int (Int32)
-import Data.Typeable (Typeable)
 import Foreign.C.String (CString, peekCString)
 import Foreign.C.Types (CInt(..))
 import Foreign.Storable (Storable(..))
@@ -44,7 +43,7 @@ type UErrorCode = CInt
 -- ICU functions.
 newtype ICUError = ICUError {
       fromErrorCode :: UErrorCode
-    } deriving (Eq, Typeable)
+    } deriving (Eq)
 
 instance Show ICUError where
     show code = "ICUError " ++ errorName code
@@ -73,7 +72,7 @@ data ParseError = ParseError {
     -- represents the offset from the start of the text.  If the
     -- parser does not support this field, it will have a value of
     -- 'Nothing'.
-    } deriving (Show, Typeable)
+    } deriving (Show)
 
 instance NFData ParseError where
     rnf ParseError{..} = rnf errError `seq` rnf errLine `seq` rnf errOffset

--- a/Data/Text/ICU/Normalize.hsc
+++ b/Data/Text/ICU/Normalize.hsc
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP, DeriveDataTypeable, ForeignFunctionInterface #-}
+{-# LANGUAGE CPP, ForeignFunctionInterface #-}
 -- |
 -- Module      : Data.Text.ICU.Normalize
 -- Copyright   : (c) 2009, 2010 Bryan O'Sullivan
@@ -41,7 +41,6 @@ import Data.Text (Text)
 import Data.Text.ICU.Error.Internal (UErrorCode, handleError, handleOverflowError)
 import Data.Text.ICU.Internal (UBool, UChar, asBool, asOrdering, useAsUCharPtr, fromUCharPtr)
 import Data.Text.ICU.Normalize.Internal (UNormalizationCheckResult, toNCR)
-import Data.Typeable (Typeable)
 import Data.Int (Int32)
 import Data.Word (Word32)
 import Foreign.C.Types (CInt(..))
@@ -172,7 +171,7 @@ data CompareOption = InputIsFCD
                    -- ^ When case folding, exclude the special I
                    -- character.  For use with Turkic
                    -- (Turkish/Azerbaijani) text data.
-                     deriving (Eq, Show, Enum, Typeable)
+                     deriving (Eq, Show, Enum)
 
 fromCompareOption :: CompareOption -> UCompareOption
 fromCompareOption InputIsFCD              = #const UNORM_INPUT_IS_FCD
@@ -193,7 +192,7 @@ data NormalizationMode
     | NFC    -- ^ Canonical decomposition followed by canonical composition.
     | NFKC   -- ^ Compatibility decomposition followed by canonical composition.
     | FCD    -- ^ \"Fast C or D\" form.
-      deriving (Eq, Show, Enum, Typeable)
+      deriving (Eq, Show, Enum)
 
 toNM :: NormalizationMode -> UNormalizationMode
 toNM None = #const UNORM_NONE
@@ -265,28 +264,28 @@ compare opts a b = unsafePerformIO .
                     (reduceCompareOptions opts)
 
 foreign import ccall unsafe "hs_text_icu.h __hs_unorm_compare" unorm_compare
-    :: Ptr UChar -> Int32 
-    -> Ptr UChar -> Int32 
+    :: Ptr UChar -> Int32
+    -> Ptr UChar -> Int32
     -> Word32
-    -> Ptr UErrorCode 
+    -> Ptr UErrorCode
     -> IO Int32
 
 foreign import ccall unsafe "hs_text_icu.h __hs_unorm_quickCheck" unorm_quickCheck
-    :: Ptr UChar -> Int32 
-    -> UNormalizationMode 
+    :: Ptr UChar -> Int32
+    -> UNormalizationMode
     -> Ptr UErrorCode
     -> IO UNormalizationCheckResult
 
 foreign import ccall unsafe "hs_text_icu.h __hs_unorm_isNormalized" unorm_isNormalized
-    :: Ptr UChar -> Int32 
-    -> UNormalizationMode 
-    -> Ptr UErrorCode 
+    :: Ptr UChar -> Int32
+    -> UNormalizationMode
+    -> Ptr UErrorCode
     -> IO UBool
 
 foreign import ccall unsafe "hs_text_icu.h __hs_unorm_normalize" unorm_normalize
-    :: Ptr UChar -> Int32 
-    -> UNormalizationMode 
+    :: Ptr UChar -> Int32
+    -> UNormalizationMode
     -> Int32
-    -> Ptr UChar -> Int32 
-    -> Ptr UErrorCode 
+    -> Ptr UChar -> Int32
+    -> Ptr UErrorCode
     -> IO Int32

--- a/Data/Text/ICU/Normalize/Internal.hsc
+++ b/Data/Text/ICU/Normalize/Internal.hsc
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP, DeriveDataTypeable, ForeignFunctionInterface #-}
+{-# LANGUAGE CPP, ForeignFunctionInterface #-}
 -- |
 -- Module      : Data.Text.ICU.Normalize.Internal
 -- Copyright   : (c) 2010 Bryan O'Sullivan

--- a/Data/Text/ICU/Normalize2.hsc
+++ b/Data/Text/ICU/Normalize2.hsc
@@ -1,4 +1,4 @@
-{-# LANGUAGE EmptyDataDecls, CPP, DeriveDataTypeable, ForeignFunctionInterface #-}
+{-# LANGUAGE EmptyDataDecls, CPP, ForeignFunctionInterface #-}
 -- |
 -- Module      : Data.Text.ICU.Normalize
 -- Copyright   : (c) 2009, 2010 Bryan O'Sullivan
@@ -38,7 +38,6 @@ import Data.Text (Text)
 import Data.Text.ICU.Error.Internal (UErrorCode, handleError, handleOverflowError)
 import Data.Text.ICU.Internal (UBool, UChar, asBool, asOrdering, fromUCharPtr, useAsUCharPtr)
 import Data.Text.ICU.Normalize.Internal (UNormalizationCheckResult, toNCR)
-import Data.Typeable (Typeable)
 import Data.Int (Int32)
 import Data.Word (Word32)
 import Foreign.C.Types (CInt(..))
@@ -165,7 +164,7 @@ data NormalizationMode
     | NFC            -- ^ Canonical decomposition followed by canonical composition.
     | NFKC           -- ^ Compatibility decomposition followed by canonical composition.
     | NFKCCasefold   -- ^ NFKC with Casefold.
-      deriving (Eq, Show, Enum, Typeable)
+      deriving (Eq, Show, Enum)
 
 createNormalizerWith :: (Ptr UErrorCode -> IO (Ptr UNormalizer2)) -> IO Normalizer
 createNormalizerWith f = Normalizer <$> handleError f
@@ -358,7 +357,7 @@ data CompareOption = InputIsFCD
                    -- ^ When case folding, exclude the special I
                    -- character.  For use with Turkic
                    -- (Turkish/Azerbaijani) text data.
-                     deriving (Eq, Show, Enum, Typeable)
+                     deriving (Eq, Show, Enum)
 
 fromCompareOption :: CompareOption -> UCompareOption
 fromCompareOption InputIsFCD              = #const UNORM_INPUT_IS_FCD

--- a/Data/Text/ICU/Number.hsc
+++ b/Data/Text/ICU/Number.hsc
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP, DeriveDataTypeable, ForeignFunctionInterface #-}
+{-# LANGUAGE CPP, ForeignFunctionInterface #-}
 -- |
 -- Module      : Data.Text.ICU.Number
 -- Copyright   : (c) 2020 Torsten Kemps-Benedix
@@ -37,7 +37,6 @@ import Data.Text.ICU.Error
 import Data.Text.ICU.Error.Internal (UErrorCode, UParseError, handleParseError, handleOverflowError)
 import Data.Text.ICU.Internal (UChar, useAsUCharPtr, fromUCharPtr)
 import Data.Text.ICU.Internal (LocaleName, withLocaleName)
-import Data.Typeable (Typeable)
 import Data.Int (Int32)
 import Foreign.C.Types (CInt(..), CDouble(..))
 import Foreign.Ptr (Ptr)
@@ -77,7 +76,7 @@ data NumberFormatStyle
     | NUM_FORMAT_STYLE_COUNT -- ^ One more than the highest normal UNumberFormatStyle value. Deprecated: ICU 58 The numeric value may change over time, see ICU ticket #12420.
     | NUM_DEFAULT -- ^ Default format.
     | NUM_IGNORE -- ^ Alias for NUM_PATTERN_DECIMAL.
-      deriving (Eq, Show, Typeable)
+      deriving (Eq, Show)
 
 type UNumberFormatStyle = CInt
 

--- a/Data/Text/ICU/Regex/Internal.hsc
+++ b/Data/Text/ICU/Regex/Internal.hsc
@@ -1,4 +1,4 @@
-{-# LANGUAGE BangPatterns, DeriveDataTypeable, EmptyDataDecls,
+{-# LANGUAGE BangPatterns, EmptyDataDecls,
     ForeignFunctionInterface, MagicHash, RecordWildCards,
     ScopedTypeVariables #-}
 
@@ -47,7 +47,6 @@ import Data.Text.ICU.Internal (UBool, UChar, UTextPtr, UText, useAsUCharPtr, wit
 import Data.Text.ICU.Error (isRegexError)
 import Data.Text.ICU.Error.Internal (UParseError, UErrorCode,
                                      handleError, handleParseError)
-import Data.Typeable (Typeable)
 import Data.Word (Word32)
 import Foreign.ForeignPtr (ForeignPtr)
 import Foreign.Ptr (FunPtr, Ptr)
@@ -119,7 +118,7 @@ data MatchOption
     -- A limit is desirable because a malicious or poorly designed
     -- pattern can use excessive memory, potentially crashing the
     -- process.  A limit is enabled by default.
-      deriving (Eq, Show, Typeable)
+      deriving (Eq, Show)
 
 -- | A compiled regular expression.
 --

--- a/Data/Text/ICU/Spoof.hsc
+++ b/Data/Text/ICU/Spoof.hsc
@@ -1,4 +1,4 @@
-{-# LANGUAGE BangPatterns, CPP, DeriveDataTypeable, ForeignFunctionInterface,
+{-# LANGUAGE BangPatterns, CPP, ForeignFunctionInterface,
     OverloadedStrings, RecordWildCards, ScopedTypeVariables #-}
 -- |
 -- Module      : Data.Text.ICU.Spoof
@@ -72,7 +72,6 @@ import Data.Text.Foreign (fromPtr)
 import Data.Text.ICU.Internal (UChar)
 import Data.Text.ICU.Internal (fromUCharPtr)
 #endif
-import Data.Typeable (Typeable)
 import Data.Word (Word8)
 import Foreign.C.String (CString, peekCString, withCString)
 import Foreign.Marshal.Utils (with)
@@ -273,7 +272,7 @@ data OpenFromSourceParseError = OpenFromSourceParseError {
       errFile :: OpenFromSourceParseErrorFile
     -- | Parse error encountered opening a spoof checker from source.
     , parseError :: ParseError
-    } deriving (Show, Typeable)
+    } deriving (Show)
 
 instance NFData OpenFromSourceParseError where
     rnf OpenFromSourceParseError{..} = rnf parseError `seq` rnf errFile


### PR DESCRIPTION
I forgot the .hsc files in #114.

CI failure is due to known problem with testsuite:
- #103
- Failure at: https://github.com/haskell/text-icu/actions/runs/25935413859/job/76239470390?pr=116
  `t_blockCode: [Failed] 'Enum.toEnum{BlockCode}: tag (328) is outside of enumeration's range (0,327)' `
